### PR TITLE
Fix wrong `dock_with` links on planetary base edits

### DIFF
--- a/fl_editor/main_window.py
+++ b/fl_editor/main_window.py
@@ -28073,8 +28073,6 @@ class MainWindow(QMainWindow):
             space_costume = str(payload.get("space_costume", "") or "").strip()
             obj_updates: dict[str, str] = {
                 "nickname": obj_nick,
-                "base": base_nick,
-                "dock_with": base_nick,
                 "archetype": safe_archetype,
                 "loadout": str(payload.get("loadout", "") or "").strip(),
                 "reputation": rep_nick,
@@ -28103,9 +28101,16 @@ class MainWindow(QMainWindow):
                 if key in removable_if_empty and not str(val).strip():
                     continue
                 new_obj_entries.append((key, val))
+            new_obj_entries = self._normalize_base_object_link_entries(
+                new_obj_entries,
+                archetype=safe_archetype,
+                base_nickname=base_nick,
+            )
 
             self._sections[sec_idx] = ("Object", new_obj_entries)
             item.data["_entries"] = list(new_obj_entries)
+            item.data.pop("base", None)
+            item.data.pop("dock_with", None)
             for k, v in new_obj_entries:
                 item.data[str(k).strip().lower()] = v
 
@@ -28225,6 +28230,36 @@ class MainWindow(QMainWindow):
             self.statusBar().showMessage(tr("status.base_updated").format(nickname=base_nick))
         finally:
             self._set_active_base_focus(previous_focus)
+
+    def _normalize_base_object_link_entries(
+        self,
+        entries: list[tuple[str, str]],
+        *,
+        archetype: str,
+        base_nickname: str,
+    ) -> list[tuple[str, str]]:
+        normalized = list(entries or [])
+        base_nick = str(base_nickname or "").strip()
+        arch = str(archetype or "").strip().lower()
+        keep_base = True
+        keep_dock_with = True
+
+        # Planetary bases use `base`, while docking helpers (ring/fixture)
+        # use `dock_with`. Standalone station bases keep both links.
+        if "planet" in arch:
+            keep_dock_with = False
+        if any(token in arch for token in ("dock_ring", "docking_fixture")):
+            keep_base = False
+
+        if base_nick and keep_base:
+            normalized = self._entry_set(normalized, "base", base_nick)
+        else:
+            normalized = self._entry_remove(normalized, "base")
+        if base_nick and keep_dock_with:
+            normalized = self._entry_set(normalized, "dock_with", base_nick)
+        else:
+            normalized = self._entry_remove(normalized, "dock_with")
+        return normalized
 
     def _npc_collect_bases(self, game_path: str) -> list[dict]:
         if not self._ensure_universe_sections_for_edit():

--- a/tests/test_main_window_smoke.py
+++ b/tests/test_main_window_smoke.py
@@ -5588,6 +5588,42 @@ def test_show_selected_3d_preview_uses_multipart_base_preview_branch(main_window
     assert calls == [("li01_01_base_obj", "Li01_01_Base")]
 
 
+def test_normalize_base_object_link_entries_keeps_planet_base_but_removes_dock_with(main_window):
+    entries = [
+        ("nickname", "Li01_01"),
+        ("archetype", "planet_manhattan"),
+        ("base", "Li01_01_Base"),
+        ("dock_with", "Li01_01_Base"),
+    ]
+
+    normalized = main_window._normalize_base_object_link_entries(
+        entries,
+        archetype="planet_manhattan",
+        base_nickname="Li01_01_Base",
+    )
+
+    assert ("base", "Li01_01_Base") in normalized
+    assert not any(str(key).strip().lower() == "dock_with" for key, _value in normalized)
+
+
+def test_normalize_base_object_link_entries_keeps_dock_ring_dock_with_but_removes_base(main_window):
+    entries = [
+        ("nickname", "Dock_Ring_Li01_01"),
+        ("archetype", "dock_ring"),
+        ("base", "Li01_01_Base"),
+        ("dock_with", "Li01_01_Base"),
+    ]
+
+    normalized = main_window._normalize_base_object_link_entries(
+        entries,
+        archetype="dock_ring",
+        base_nickname="Li01_01_Base",
+    )
+
+    assert ("dock_with", "Li01_01_Base") in normalized
+    assert not any(str(key).strip().lower() == "base" for key, _value in normalized)
+
+
 def test_base_nickname_for_object_uses_root_nickname_when_children_reference_parent(main_window):
     root_obj = SolarObject(
         {


### PR DESCRIPTION
## Summary
- normalize base link fields when saving edited base objects
- keep `base` on planets but remove `dock_with`
- keep `dock_with` on dock rings/fixtures but remove `base`
- add regression coverage for planet and dock ring link normalization

## Testing
- `.\.venv\Scripts\python.exe -m pytest tests/test_main_window_smoke.py -k "normalize_base_object_link_entries or show_selected_3d_preview_uses_multipart_base_preview_branch"`
- `.\.venv\Scripts\python.exe -m pytest tests/test_base_creation.py tests/test_docking_ring_logic.py -q`

Closes #12.