### PR TITLE
Fix starsphere background options not showing new files

### DIFF
--- a/fl_editor/main_window.py
+++ b/fl_editor/main_window.py
@@ -34125,6 +34125,9 @@ class MainWindow(QMainWindow):
                                 bg_vals[lk].add(v)
         except Exception:
             pass
+        scanned_bg = self._scan_starsphere_background_options(game_path)
+        for key in bg_vals:
+            bg_vals[key].update(scanned_bg.get(key, []))
 
         factions = list(self._cached_faction_labels) if self._cached_faction_labels else list(self._cached_factions)
 
@@ -37329,6 +37332,9 @@ class MainWindow(QMainWindow):
                                     dust_vals.add(v)
             except Exception:
                 pass
+            scanned_bg = self._scan_starsphere_background_options(game_path)
+            for key in bg_vals:
+                bg_vals[key].update(scanned_bg.get(key, []))
         self._cached_music_opts = {
             "space": sorted(music_vals["space"], key=str.lower),
             "danger": sorted(music_vals["danger"], key=str.lower),
@@ -37363,6 +37369,32 @@ class MainWindow(QMainWindow):
                     pass
         group_rows.sort(key=lambda x: x[0].lower())
         self._build_faction_label_cache(group_rows)
+
+    def _scan_starsphere_background_options(self, game_path: str) -> dict[str, list[str]]:
+        starsphere_dir = self._resolve_data_subdir_case_insensitive(game_path, "SOLAR/STARSPHERE")
+        out = {"basic_stars": [], "complex_stars": [], "nebulae": []}
+        if starsphere_dir is None or not starsphere_dir.is_dir():
+            return out
+        basic: set[str] = set()
+        complex_vals: set[str] = set()
+        nebulae: set[str] = set()
+        try:
+            for entry in starsphere_dir.iterdir():
+                if not entry.is_file() or entry.suffix.lower() != ".cmp":
+                    continue
+                rel_path = f"solar\\starsphere\\{entry.name}"
+                stem = entry.stem.lower()
+                nebulae.add(rel_path)
+                if "stars" in stem:
+                    complex_vals.add(rel_path)
+                if "basic" in stem:
+                    basic.add(rel_path)
+        except Exception:
+            return out
+        out["basic_stars"] = sorted(basic, key=str.lower)
+        out["complex_stars"] = sorted(complex_vals, key=str.lower)
+        out["nebulae"] = sorted(nebulae, key=str.lower)
+        return out
 
     def _refresh_system_fields(self):
         """Aktualisiert den Button-Text mit dem System-Kürzel."""

--- a/tests/test_main_window_smoke.py
+++ b/tests/test_main_window_smoke.py
@@ -7901,3 +7901,22 @@ def test_open_zone_editor_for_exclusion_zone_updates_linked_nebula_shell_setting
     assert written.count("zone_shell =") == 1
     assert "zone_shell = solar\\nebula\\crow_exclusion.3db" in written
     assert main_window._undo_actions[-1]["linked_file_rel"] == "solar\\nebula\\LI05_nebula.ini"
+
+
+def test_scan_starsphere_background_options_reads_new_cmp_files_from_starsphere_dir(main_window, monkeypatch, tmp_path: Path):
+    starsphere_dir = tmp_path / "DATA" / "SOLAR" / "starsphere"
+    starsphere_dir.mkdir(parents=True)
+    (starsphere_dir / "starsphere_custom_basic.cmp").write_text("", encoding="utf-8")
+    (starsphere_dir / "starsphere_custom_stars.cmp").write_text("", encoding="utf-8")
+    (starsphere_dir / "starsphere_custom_nebula.cmp").write_text("", encoding="utf-8")
+    (starsphere_dir / "ignore.txt").write_text("", encoding="utf-8")
+
+    monkeypatch.setattr(main_window, "_primary_game_path", lambda: str(tmp_path))
+
+    result = main_window._scan_starsphere_background_options(str(tmp_path))
+
+    assert r"solar\starsphere\starsphere_custom_basic.cmp" in result["basic_stars"]
+    assert r"solar\starsphere\starsphere_custom_basic.cmp" in result["complex_stars"]
+    assert r"solar\starsphere\starsphere_custom_stars.cmp" in result["complex_stars"]
+    assert r"solar\starsphere\starsphere_custom_nebula.cmp" in result["nebulae"]
+    assert all(not value.endswith("ignore.txt") for values in result.values() for value in values)


### PR DESCRIPTION
## Summary
- scan `DATA/SOLAR/starsphere` for available `*.cmp` files
- merge scanned starsphere files into the background dropdown options
- keep existing system-derived background values and add a regression test for newly added starspheres

## Why
The background lists were only populated from already existing system INI entries. That meant new starspheres added under `solar\starsphere` would not appear in FLAtlas until they were already used somewhere.

## Testing
- `.\.venv\Scripts\python.exe -m pytest tests/test_main_window_smoke.py -k starsphere_background_options -q`

Closes #6.