### PR TITLE
Disable Base Builder for planets and docking rings

### DIFF
--- a/fl_editor/main_window.py
+++ b/fl_editor/main_window.py
@@ -23655,9 +23655,22 @@ class MainWindow(QMainWindow):
                 return True
         return False
 
+    @staticmethod
+    def _is_base_builder_supported_root_object(obj: SolarObject | None) -> bool:
+        if not isinstance(obj, SolarObject):
+            return False
+        arch = str(obj.data.get("archetype", "") or "").strip().lower()
+        if "planet" in arch:
+            return False
+        if any(token in arch for token in ("dock_ring", "docking_fixture")):
+            return False
+        return True
+
     def _selected_can_open_base_builder(self) -> bool:
         obj = self._selected
         if not isinstance(obj, SolarObject):
+            return False
+        if not self._is_base_builder_child_object(obj) and not self._is_base_builder_supported_root_object(obj):
             return False
         return bool(self._base_nickname_for_object(obj))
 
@@ -24352,10 +24365,11 @@ class MainWindow(QMainWindow):
                 act_create_npc.triggered.connect(
                     lambda checked=False, b=base_nick: self._open_npc_editor(b)
                 )
-                act_base_builder = menu.addAction(tr("ctx.base_builder"))
-                act_base_builder.triggered.connect(
-                    lambda checked=False, o=item: self._open_base_builder_for_object(o)
-                )
+                if self._is_base_builder_child_object(item) or self._is_base_builder_supported_root_object(item):
+                    act_base_builder = menu.addAction(tr("ctx.base_builder"))
+                    act_base_builder.triggered.connect(
+                        lambda checked=False, o=item: self._open_base_builder_for_object(o)
+                    )
             act_rot_l = menu.addAction(tr("ctx.rotate_y_neg"))
             act_rot_l.triggered.connect(lambda: self._rotate_selected_object(-15.0, axis=1))
             act_rot_r = menu.addAction(tr("ctx.rotate_y_pos"))
@@ -27735,6 +27749,8 @@ class MainWindow(QMainWindow):
         item = obj if isinstance(obj, SolarObject) else self._selected
         if not isinstance(item, SolarObject):
             QMessageBox.information(self, tr("msg.no_object"), tr("msg.no_object_text"))
+            return
+        if not self._is_base_builder_child_object(item) and not self._is_base_builder_supported_root_object(item):
             return
         base_nick = self._base_nickname_for_object(item)
         if not base_nick:

--- a/tests/test_main_window_smoke.py
+++ b/tests/test_main_window_smoke.py
@@ -4653,6 +4653,81 @@ def test_base_builder_sidebar_button_opens_for_child_selection(main_window, monk
     assert opened == [None]
 
 
+def test_base_builder_button_disabled_for_planet_and_dock_ring_roots(main_window):
+    planet_obj = SolarObject(
+        {
+            "nickname": "li01_planet",
+            "archetype": "planet_earthgrncld_4000",
+            "base": "Li01_01_Base",
+            "_entries": [
+                ("nickname", "li01_planet"),
+                ("archetype", "planet_earthgrncld_4000"),
+                ("base", "Li01_01_Base"),
+            ],
+        },
+        main_window._scale,
+    )
+    ring_obj = SolarObject(
+        {
+            "nickname": "li01_planet_ring",
+            "archetype": "dock_ring",
+            "dock_with": "Li01_01_Base",
+            "_entries": [
+                ("nickname", "li01_planet_ring"),
+                ("archetype", "dock_ring"),
+                ("dock_with", "Li01_01_Base"),
+            ],
+        },
+        main_window._scale,
+    )
+
+    main_window._selected = planet_obj
+    main_window._refresh_editing_action_states()
+    assert main_window.base_builder_btn.isEnabled() is False
+
+    main_window._selected = ring_obj
+    main_window._refresh_editing_action_states()
+    assert main_window.base_builder_btn.isEnabled() is False
+
+
+def test_open_base_builder_ignores_planet_and_dock_ring_roots(main_window, monkeypatch):
+    planet_obj = SolarObject(
+        {
+            "nickname": "li01_planet",
+            "archetype": "planet_earthgrncld_4000",
+            "base": "Li01_01_Base",
+            "_entries": [
+                ("nickname", "li01_planet"),
+                ("archetype", "planet_earthgrncld_4000"),
+                ("base", "Li01_01_Base"),
+            ],
+        },
+        main_window._scale,
+    )
+    ring_obj = SolarObject(
+        {
+            "nickname": "li01_planet_ring",
+            "archetype": "dock_ring",
+            "dock_with": "Li01_01_Base",
+            "_entries": [
+                ("nickname", "li01_planet_ring"),
+                ("archetype", "dock_ring"),
+                ("dock_with", "Li01_01_Base"),
+            ],
+        },
+        main_window._scale,
+    )
+
+    calls: list[str] = []
+    monkeypatch.setattr(main_window, "_collect_base_builder_part_entries", lambda: calls.append("collect") or [])
+    monkeypatch.setattr(main_window, "_initialize_base_builder_draft", lambda *_args, **_kwargs: calls.append("init"))
+
+    main_window._open_base_builder_for_object(planet_obj)
+    main_window._open_base_builder_for_object(ring_obj)
+
+    assert calls == []
+
+
 def test_show_base_related_3d_preview_uses_dedicated_preview_view(main_window, monkeypatch):
     obj = SolarObject(
         {


### PR DESCRIPTION
## Summary
- prevent the Base Builder button from enabling on planets and docking rings
- hide the Base Builder context-menu entry for unsupported root objects
- add a hard guard in `_open_base_builder_for_object()` so direct calls also do nothing for those objects
- keep child-object based base-builder access working for valid multipart bases

## Testing
- `.\.venv\Scripts\python.exe -m pytest tests/test_main_window_smoke.py -k "base_builder_sidebar_button_opens_for_child_selection or base_builder_button_disabled_for_planet_and_dock_ring_roots or open_base_builder_ignores_planet_and_dock_ring_roots"`

Closes #13.