### PR TITLE
Fix docking ring creation workflow and planetary base normalization

### DIFF
--- a/fl_editor/base_scaffolding.py
+++ b/fl_editor/base_scaffolding.py
@@ -110,13 +110,17 @@ def normalize_room_navigation(
     all_rooms: list[str],
     start_room: str,
 ) -> str:
-    del room_name
     nav_expected = build_nav_hotspots(all_rooms, start_room)
     lines = str(content or "").splitlines()
     result: list[str] = []
     i = 0
     insertion_point: int | None = None
     preserved_exit_names: set[str] = set()
+    preserved_exit_targets: set[str] = set()
+    valid_targets = {str(room or "").strip().lower() for room in all_rooms if str(room or "").strip()}
+    room_name_key = str(room_name or "").strip().lower()
+    if room_name_key:
+        valid_targets.add(room_name_key)
 
     while i < len(lines):
         stripped = lines[i].strip().lower()
@@ -129,6 +133,7 @@ def normalize_room_navigation(
             is_exit_door = False
             has_virtual_target = False
             hotspot_name = ""
+            room_switch_target = ""
             for line in block:
                 stripped_line = line.strip()
                 if "=" not in stripped_line:
@@ -142,9 +147,15 @@ def normalize_room_navigation(
                     has_virtual_target = True
                 elif key == "name" and value:
                     hotspot_name = value
+                elif key == "room_switch" and value:
+                    room_switch_target = value
             if is_exit_door and not has_virtual_target:
                 if insertion_point is None:
                     insertion_point = len(result)
+                target_key = str(room_switch_target or "").strip().lower()
+                if target_key and target_key in valid_targets:
+                    preserved_exit_targets.add(target_key)
+                    result.extend(block)
                 continue
             if is_exit_door and has_virtual_target and hotspot_name:
                 preserved_exit_names.add(hotspot_name.strip().lower())
@@ -161,6 +172,8 @@ def normalize_room_navigation(
 
     nav_lines: list[str] = []
     for hotspot_name, target in nav_expected:
+        if str(target).strip().lower() in preserved_exit_targets:
+            continue
         if str(hotspot_name).strip().lower() in preserved_exit_names:
             continue
         nav_lines.extend(

--- a/fl_editor/dialogs.py
+++ b/fl_editor/dialogs.py
@@ -5804,6 +5804,7 @@ class DockingRingDialog(QDialog):
         existing_bases: list[str] | list[tuple[str, str]] | None = None,
         pilots: list[str] | None = None,
         voices: list[str] | None = None,
+        template_room_names_provider: Callable[[str], list[str]] | None = None,
         *,
         needs_base: bool = True,
         default_faction: str = "",
@@ -5815,6 +5816,7 @@ class DockingRingDialog(QDialog):
         self.setWindowTitle(tr("dlg.docking_ring"))
         self.setMinimumWidth(520)
         self._needs_base = needs_base
+        self._template_room_names_provider = template_room_names_provider
 
         scroll = QScrollArea(self)
         scroll.setWidgetResizable(True)
@@ -5927,12 +5929,10 @@ class DockingRingDialog(QDialog):
             # --- Rooms ---
             grp_rooms = QGroupBox(tr("dlg.grp_rooms"))
             gl_rooms = QVBoxLayout(grp_rooms)
+            self._rooms_layout = gl_rooms
             self.room_checks: dict[str, QCheckBox] = {}
             for room_name, default_on in self.ROOM_CHOICES:
-                cb = QCheckBox(room_name)
-                cb.setChecked(default_on)
-                gl_rooms.addWidget(cb)
-                self.room_checks[room_name] = cb
+                self._ensure_room_checkbox(room_name, default_on)
 
             self.start_room_cb = QComboBox()
             sr_row = QHBoxLayout()
@@ -5977,6 +5977,8 @@ class DockingRingDialog(QDialog):
             )
             gl_tpl.addRow(tr("dlg.copy_rooms_from"), self.template_cb)
             layout.addRow(grp_tpl)
+            self.template_cb.currentIndexChanged.connect(self._on_template_changed)
+            self._on_template_changed()
         else:
             # Planet hat schon eine Base – nur base_nick merken
             self._existing_base_nick = base_nickname
@@ -6001,6 +6003,41 @@ class DockingRingDialog(QDialog):
         if str(room_state["start_room"]):
             self.start_room_cb.setCurrentText(str(room_state["start_room"]))
         self.start_room_cb.blockSignals(False)
+
+    def _ensure_room_checkbox(self, room_name: str, default_on: bool = False) -> QCheckBox:
+        name = str(room_name or "").strip()
+        if not name:
+            raise ValueError("room_name must not be empty")
+        cb = self.room_checks.get(name)
+        if cb is not None:
+            return cb
+        cb = QCheckBox(name)
+        cb.setChecked(bool(default_on))
+        cb.toggled.connect(self._refresh_start_room_choices)
+        self._rooms_layout.addWidget(cb)
+        self.room_checks[name] = cb
+        return cb
+
+    def _on_template_changed(self, *_args):
+        if not self._needs_base or self._template_room_names_provider is None:
+            return
+        template_base = str(self.template_cb.currentData() or self.template_cb.currentText() or "").strip()
+        if not template_base:
+            return
+        try:
+            room_names = [str(name or "").strip() for name in list(self._template_room_names_provider(template_base) or [])]
+        except Exception:
+            room_names = []
+        room_names = [name for name in room_names if name]
+        if not room_names:
+            return
+        selected = {name.lower() for name in room_names}
+        for existing_name, cb in list(self.room_checks.items()):
+            cb.setChecked(existing_name.lower() in selected)
+        for room_name in room_names:
+            self._ensure_room_checkbox(room_name, True).setChecked(True)
+        preferred = "Deck" if any(name == "Deck" for name in room_names) else room_names[0]
+        self._refresh_start_room_choices(preferred=preferred)
 
     def payload(self) -> dict:
         return build_docking_ring_payload(

--- a/fl_editor/dialogs.py
+++ b/fl_editor/dialogs.py
@@ -5768,6 +5768,10 @@ class BaseEditDialog(QDialog):
 class DockingRingDialog(QDialog):
     """Kombinierter Dialog: erstellt Docking Ring UND zugehörige Base/Rooms."""
 
+    DEFAULT_IDS_INFO = "66141"
+    FIXTURE_IDS_NAME = "261166"
+    FIXTURE_IDS_INFO = "66489"
+
     ROOM_CHOICES = [
         ("Deck", True),
         ("Bar", True),
@@ -5797,12 +5801,15 @@ class DockingRingDialog(QDialog):
         base_nickname: str,
         loadouts: list[str],
         factions: list[str],
-        existing_bases: list[str] | None = None,
+        existing_bases: list[str] | list[tuple[str, str]] | None = None,
         pilots: list[str] | None = None,
         voices: list[str] | None = None,
         *,
         needs_base: bool = True,
         default_faction: str = "",
+        ids_name_text: str = "",
+        ids_info_value: str = DEFAULT_IDS_INFO,
+        strid_name_value: int = 0,
     ):
         super().__init__(parent)
         self.setWindowTitle(tr("dlg.docking_ring"))
@@ -5883,10 +5890,18 @@ class DockingRingDialog(QDialog):
         gl_ring.addRow("Difficulty Level:", self.diff_spin)
 
         # IDS
-        self.ids_name_edit = QLineEdit("0")
-        gl_ring.addRow("ids_name:", self.ids_name_edit)
-        self.ids_info_edit = QLineEdit("0")
+        self.ids_name_edit = QLineEdit(str(ids_name_text or "").strip())
+        self.ids_name_edit.setPlaceholderText("Planet Name Docking Ring")
+        gl_ring.addRow("Name:", self.ids_name_edit)
+        self.ids_info_edit = QLineEdit(str(ids_info_value or self.DEFAULT_IDS_INFO).strip())
         gl_ring.addRow("ids_info:", self.ids_info_edit)
+
+        self.create_fixture_cb = QCheckBox("Create docking_fixture")
+        self.create_fixture_cb.setChecked(False)
+        self.create_fixture_cb.setToolTip(
+            f"Creates a docking_fixture above the ring with ids_name={self.FIXTURE_IDS_NAME} and ids_info={self.FIXTURE_IDS_INFO}."
+        )
+        gl_ring.addRow("", self.create_fixture_cb)
 
         layout.addRow(grp_ring)
 
@@ -5903,7 +5918,7 @@ class DockingRingDialog(QDialog):
 
             self.strid_name_spin = QSpinBox()
             self.strid_name_spin.setRange(0, 999999)
-            self.strid_name_spin.setValue(0)
+            self.strid_name_spin.setValue(int(strid_name_value or 0))
             self.strid_name_spin.setToolTip("strid_name für universe.ini")
             gl_base.addRow("strid_name:", self.strid_name_spin)
 
@@ -5947,7 +5962,16 @@ class DockingRingDialog(QDialog):
             self.template_cb.setEditable(True)
             self.template_cb.addItem("")
             if existing_bases:
-                self.template_cb.addItems(existing_bases)
+                for item in existing_bases:
+                    if isinstance(item, tuple) and len(item) >= 2:
+                        label = str(item[0] or "").strip()
+                        nick = str(item[1] or "").strip()
+                        if label and nick:
+                            self.template_cb.addItem(label, nick)
+                    else:
+                        txt = str(item or "").strip()
+                        if txt:
+                            self.template_cb.addItem(txt, txt)
             self.template_cb.setToolTip(
                 tr("dlg.copy_rooms_tip")
             )
@@ -5997,5 +6021,6 @@ class DockingRingDialog(QDialog):
             room_names=[name for name, cb in self.room_checks.items() if cb.isChecked()] if self._needs_base else [],
             start_room=self.start_room_cb.currentText().strip() if self._needs_base else "",
             price_variance=self.price_var_spin.value() if self._needs_base else 0.15,
-            template_base=self.template_cb.currentText().strip() if self._needs_base else "",
+            template_base=(str(self.template_cb.currentData() or self.template_cb.currentText()).strip() if self._needs_base else ""),
+            create_fixture=bool(self.create_fixture_cb.isChecked()),
         )

--- a/fl_editor/dialogs.py
+++ b/fl_editor/dialogs.py
@@ -5771,6 +5771,7 @@ class DockingRingDialog(QDialog):
     DEFAULT_IDS_INFO = "66141"
     FIXTURE_IDS_NAME = "261166"
     FIXTURE_IDS_INFO = "66489"
+    TEMPLATE_START_ROOM_PREFERENCE = ("Cityscape", "Planetscape", "Deck")
 
     ROOM_CHOICES = [
         ("Deck", True),
@@ -5976,6 +5977,9 @@ class DockingRingDialog(QDialog):
                 tr("dlg.copy_rooms_tip")
             )
             gl_tpl.addRow(tr("dlg.copy_rooms_from"), self.template_cb)
+            self.copy_npcs_cb = QCheckBox("Copy NPCs")
+            self.copy_npcs_cb.setChecked(True)
+            gl_tpl.addRow("", self.copy_npcs_cb)
             layout.addRow(grp_tpl)
             self.template_cb.currentIndexChanged.connect(self._on_template_changed)
             self._on_template_changed()
@@ -6036,7 +6040,10 @@ class DockingRingDialog(QDialog):
             cb.setChecked(existing_name.lower() in selected)
         for room_name in room_names:
             self._ensure_room_checkbox(room_name, True).setChecked(True)
-        preferred = "Deck" if any(name == "Deck" for name in room_names) else room_names[0]
+        preferred = next(
+            (name for name in self.TEMPLATE_START_ROOM_PREFERENCE if any(room == name for room in room_names)),
+            room_names[0],
+        )
         self._refresh_start_room_choices(preferred=preferred)
 
     def payload(self) -> dict:
@@ -6060,4 +6067,5 @@ class DockingRingDialog(QDialog):
             price_variance=self.price_var_spin.value() if self._needs_base else 0.15,
             template_base=(str(self.template_cb.currentData() or self.template_cb.currentText()).strip() if self._needs_base else ""),
             create_fixture=bool(self.create_fixture_cb.isChecked()),
+            copy_template_npcs=bool(self.copy_npcs_cb.isChecked()) if self._needs_base and hasattr(self, "copy_npcs_cb") else False,
         )

--- a/fl_editor/docking_ring_logic.py
+++ b/fl_editor/docking_ring_logic.py
@@ -44,6 +44,7 @@ def build_docking_ring_payload(
     start_room: str = "",
     price_variance: float = 0.15,
     template_base: str = "",
+    create_fixture: bool = False,
 ) -> dict:
     room_state = build_docking_ring_room_state(
         room_names=room_names,
@@ -60,6 +61,7 @@ def build_docking_ring_payload(
         "difficulty": int(difficulty),
         "ids_name": str(ids_name or "").strip(),
         "ids_info": str(ids_info or "").strip(),
+        "create_fixture": bool(create_fixture),
     }
     if needs_base:
         result.update(

--- a/fl_editor/docking_ring_logic.py
+++ b/fl_editor/docking_ring_logic.py
@@ -45,6 +45,7 @@ def build_docking_ring_payload(
     price_variance: float = 0.15,
     template_base: str = "",
     create_fixture: bool = False,
+    copy_template_npcs: bool = True,
 ) -> dict:
     room_state = build_docking_ring_room_state(
         room_names=room_names,
@@ -62,6 +63,7 @@ def build_docking_ring_payload(
         "ids_name": str(ids_name or "").strip(),
         "ids_info": str(ids_info or "").strip(),
         "create_fixture": bool(create_fixture),
+        "copy_template_npcs": bool(copy_template_npcs),
     }
     if needs_base:
         result.update(

--- a/fl_editor/main_window.py
+++ b/fl_editor/main_window.py
@@ -28254,10 +28254,12 @@ class MainWindow(QMainWindow):
         *,
         archetype: str,
         base_nickname: str,
+        reputation: str = "",
     ) -> list[tuple[str, str]]:
         normalized = list(entries or [])
         base_nick = str(base_nickname or "").strip()
         arch = str(archetype or "").strip().lower()
+        rep = str(reputation or "").strip()
         keep_base = True
         keep_dock_with = True
 
@@ -28276,6 +28278,13 @@ class MainWindow(QMainWindow):
             normalized = self._entry_set(normalized, "dock_with", base_nick)
         else:
             normalized = self._entry_remove(normalized, "dock_with")
+        if "planet" in arch:
+            # Vanilla planetary base objects only keep their base link and reputation.
+            # Dock/helper fields on the planet itself can suppress or confuse space labels.
+            for key in ("loadout", "voice", "pilot", "space_costume", "behavior", "difficulty_level"):
+                normalized = self._entry_remove(normalized, key)
+            if rep:
+                normalized = self._entry_set(normalized, "reputation", rep)
         return normalized
 
     def _npc_collect_bases(self, game_path: str) -> list[dict]:
@@ -31056,6 +31065,7 @@ class MainWindow(QMainWindow):
         base_nick = dr.get("base_nick", data_in.get("base_nickname", ""))
         planet_item = dr["planet_item"]
         planet_nick = dr["planet_nick"]
+        faction = self._faction_from_ui(str(data_in.get("faction", "") or "").strip())
 
         # Winkel berechnen (Szenen-Koordinaten → Spielkoordinaten)
         dx = pos.x() - cx
@@ -31196,11 +31206,24 @@ class MainWindow(QMainWindow):
                 except Exception as exc:
                     patch_result.append(f"mbases.ini: template NPC copy failed ({exc})")
 
-            # 4) 'base = ...' zum Planeten-Objekt hinzufügen
-            elist = list(planet_item.data.get("_entries", []))
-            elist.append(("base", base_nick))
+            # 4) Planet für Vanilla-Style planetary base links normalisieren.
+            planet_rep = faction or self._entry_get_value(list(planet_item.data.get("_entries", [])), "reputation").strip()
+            planet_arch = str(
+                planet_item.data.get("archetype")
+                or planet_item.data.get("Archetype")
+                or self._entry_get_value(list(planet_item.data.get("_entries", [])), "archetype")
+                or self._entry_get_value(list(planet_item.data.get("_entries", [])), "Archetype")
+            ).strip()
+            elist = self._normalize_base_object_link_entries(
+                list(planet_item.data.get("_entries", [])),
+                archetype=planet_arch,
+                base_nickname=base_nick,
+                reputation=planet_rep,
+            )
             planet_item.data["_entries"] = elist
             planet_item.data["base"] = base_nick
+            if planet_rep:
+                planet_item.data["reputation"] = planet_rep
 
             pnick_l = planet_nick.lower()
             for i, (sec_name, sec_entries) in enumerate(self._sections):
@@ -31208,7 +31231,15 @@ class MainWindow(QMainWindow):
                     continue
                 for k, v in sec_entries:
                     if k.lower() == "nickname" and v.strip().lower() == pnick_l:
-                        sec_entries.append(("base", base_nick))
+                        self._sections[i] = (
+                            sec_name,
+                            self._normalize_base_object_link_entries(
+                                list(sec_entries),
+                                archetype=planet_arch,
+                                base_nickname=base_nick,
+                                reputation=planet_rep,
+                            ),
+                        )
                         break
 
         # ── Docking-Ring-Objekt erstellen ─────────────────────────────
@@ -31245,7 +31276,6 @@ class MainWindow(QMainWindow):
         if pilot:
             entries.append(("pilot", pilot))
         entries.append(("difficulty_level", str(data_in.get("difficulty", 1))))
-        faction = self._faction_from_ui(data_in.get("faction", "").strip())
         if faction:
             entries.append(("reputation", faction))
 

--- a/fl_editor/main_window.py
+++ b/fl_editor/main_window.py
@@ -142,6 +142,7 @@ from .base_template_loading import (
     load_base_template_virtual_room_targets,
     load_template_rooms,
 )
+from .base_dialog_logic import make_copied_npc_rows
 from .base_creation import build_base_object_entries, build_universe_base_entries, update_universe_base_entries
 from .cmp_loader import build_native_model_info_text, load_native_freelancer_model
 from .character_3d_preview import FreelancerModelPreviewWidget
@@ -31082,6 +31083,7 @@ class MainWindow(QMainWindow):
             rooms = data_in.get("rooms", [])
             start_room = data_in.get("start_room", "Deck")
             template_base = data_in.get("template_base", "")
+            copy_template_npcs = bool(data_in.get("copy_template_npcs", False))
 
             sys_dir = Path(self._filepath).parent
             bases_dir = sys_dir / "BASES"
@@ -31155,6 +31157,44 @@ class MainWindow(QMainWindow):
                     patch_result.append(f"mbases.ini: created MBase for {base_nick}")
             except Exception as exc:
                 patch_result.append(f"mbases.ini: could not create MBase ({exc})")
+
+            if template_base and copy_template_npcs:
+                try:
+                    template_room_npcs = self._load_base_template_room_npcs(game_path, template_base)
+                    used_nicks: set[str] = set()
+                    npc_customizations: dict[str, dict[str, list[dict[str, str]]]] = {}
+                    rep_display = str(data_in.get("faction", "") or "").strip()
+                    for room_name, rows in dict(template_room_npcs or {}).items():
+                        room_key = str(room_name or "").strip().lower()
+                        if not room_key:
+                            continue
+                        copied_rows = make_copied_npc_rows(
+                            str(room_name or "").strip(),
+                            list(rows or []),
+                            used_nicks,
+                            base_nickname=base_nick,
+                            base_reputation_display=rep_display,
+                        )
+                        if copied_rows:
+                            npc_customizations[room_key] = {"npc_rows": copied_rows}
+                    npc_rooms, npc_customizations = normalize_room_npc_customizations(
+                        existing_rooms=[],
+                        selected_rooms=rooms,
+                        room_customizations=npc_customizations,
+                        room_npcs_existing={},
+                    )
+                    npc_created = self._apply_room_npcs_to_base(
+                        game_path=game_path,
+                        base_nick=base_nick,
+                        local_faction=ring_fac,
+                        room_customizations=npc_customizations,
+                        valid_rooms=npc_rooms,
+                        randomize_npc_head_body=False,
+                    )
+                    if npc_created > 0:
+                        patch_result.append(f"mbases.ini: copied {npc_created} template NPC(s)")
+                except Exception as exc:
+                    patch_result.append(f"mbases.ini: template NPC copy failed ({exc})")
 
             # 4) 'base = ...' zum Planeten-Objekt hinzufügen
             elist = list(planet_item.data.get("_entries", []))

--- a/fl_editor/main_window.py
+++ b/fl_editor/main_window.py
@@ -30850,27 +30850,34 @@ class MainWindow(QMainWindow):
                                     existing_nums.append(int(mid))
                             break
             next_num = max(existing_nums, default=0) + 1
-            base_nick = f"{sys_upper}_{next_num:02d}_Base"
+            base_nick = f"{sys_nick}_{next_num:02d}_Base"
+
+        planet_ids_name = self._entry_get_value(item.data.get("_entries", []), "ids_name").strip()
+        planet_strid_name_value = int(planet_ids_name) if planet_ids_name.isdigit() else 0
+        planet_display_name = self._display_name_from_ids_name(planet_ids_name).strip() if planet_ids_name else ""
+        if not planet_display_name:
+            planet_display_name = planet_nick
+        ring_ids_name_text = f"{planet_display_name} Docking Ring".strip()
 
         # Existierende Bases für Template-Dropdown
         existing_bases: list[tuple[str, str]] = []
         for sec_name, entries in self._uni_sections:
             if sec_name.lower() == "base":
-                base_nick = ""
+                existing_base_nick = ""
                 base_strid = ""
                 for k, v in entries:
                     kl = k.lower()
                     if kl == "nickname":
-                        base_nick = v.strip()
+                        existing_base_nick = v.strip()
                     elif kl == "strid_name":
                         base_strid = v.strip()
-                if base_nick:
-                    base_label = self._base_display_name(base_nick, base_strid)
-                    if base_label and base_label.lower() != base_nick.lower():
-                        base_label = f"{base_label} ({base_nick})"
+                if existing_base_nick:
+                    base_label = self._base_display_name(existing_base_nick, base_strid)
+                    if base_label and base_label.lower() != existing_base_nick.lower():
+                        base_label = f"{base_label} ({existing_base_nick})"
                     elif not base_label:
-                        base_label = base_nick
-                    existing_bases.append((base_label, base_nick))
+                        base_label = existing_base_nick
+                    existing_bases.append((base_label, existing_base_nick))
 
         # Listen zusammenbauen
         loadouts = [
@@ -30897,6 +30904,9 @@ class MainWindow(QMainWindow):
             voices=voices,
             needs_base=needs_base,
             default_faction=self._current_system_local_faction_ui_label(),
+            ids_name_text=ring_ids_name_text,
+            ids_info_value=str(getattr(DockingRingDialog, "DEFAULT_IDS_INFO", "66141") or "66141"),
+            strid_name_value=planet_strid_name_value,
         )
         if dlg.exec() != QDialog.Accepted:
             self._pending_dock_ring = None
@@ -31157,10 +31167,21 @@ class MainWindow(QMainWindow):
                         break
 
         # ── Docking-Ring-Objekt erstellen ─────────────────────────────
+        ids_name_value = str(data_in.get("ids_name", "") or "").strip()
+        if ids_name_value and not ids_name_value.isdigit():
+            if self._has_ids_resource_toolchain():
+                try:
+                    ids_name_value = str(self._ensure_ids_name_in_user_dll("0", ids_name_value) or "0")
+                except Exception as exc:
+                    QMessageBox.warning(self, tr("msg.save_error"), f"ids_name not written: {exc}")
+                    ids_name_value = "0"
+            else:
+                ids_name_value = "0"
+
         entries: list[tuple[str, str]] = [
             ("nickname", nickname),
-            ("ids_name", data_in.get("ids_name", "0")),
-            ("ids_info", data_in.get("ids_info", "0")),
+            ("ids_name", ids_name_value or "0"),
+            ("ids_info", str(data_in.get("ids_info", DockingRingDialog.DEFAULT_IDS_INFO) or DockingRingDialog.DEFAULT_IDS_INFO)),
             ("pos", pos_str),
             ("rotate", rotate),
             ("Archetype", data_in.get("archetype", "dock_ring")),
@@ -31173,7 +31194,8 @@ class MainWindow(QMainWindow):
             entries.append(("voice", voice))
         costume = data_in.get("costume", "").strip()
         if costume:
-            entries.append(("space_costume", costume))
+            ring_costume = costume if "," in costume else f", {costume}"
+            entries.append(("space_costume", ring_costume))
         pilot = data_in.get("pilot", "").strip()
         if pilot:
             entries.append(("pilot", pilot))
@@ -31185,6 +31207,23 @@ class MainWindow(QMainWindow):
         self._remove_dock_ring_orbit()
         self._add_object_from_entries(entries, "Object")
         patch_result.append(tr("result.dock_ring_created").format(nickname=nickname))
+
+        if bool(data_in.get("create_fixture", False)):
+            fixture_nick = self._next_available_docking_fixture_nickname(sys_nick)
+            fixture_entries: list[tuple[str, str]] = [
+                ("nickname", fixture_nick),
+                ("ids_name", DockingRingDialog.FIXTURE_IDS_NAME),
+                ("pos", f"{rx:.2f}, {py + 350.0:.2f}, {rz:.2f}"),
+                ("Archetype", "docking_fixture"),
+                ("ids_info", DockingRingDialog.FIXTURE_IDS_INFO),
+                ("behavior", "NOTHING"),
+                ("dock_with", base_nick),
+                ("base", base_nick),
+            ]
+            if faction:
+                fixture_entries.append(("reputation", faction))
+            self._add_object_from_entries(fixture_entries, "Object")
+            patch_result.append(f"docking_fixture created: {fixture_nick}")
 
         self._set_dirty(True)
         self._write_to_file(reload=False)
@@ -31203,6 +31242,21 @@ class MainWindow(QMainWindow):
                 nickname=nickname, planet=planet_nick, base=base_nick
             )
         )
+
+    def _next_available_docking_fixture_nickname(self, sys_nick: str) -> str:
+        prefix = f"{str(sys_nick or '').strip()}_docking_fixture_"
+        next_num = 1
+        used: set[int] = set()
+        for obj in list(getattr(self, "_objects", []) or []):
+            nick = str(getattr(obj, "data", {}).get("nickname", "") or "").strip()
+            if not nick.lower().startswith(prefix.lower()):
+                continue
+            suffix = nick[len(prefix):].strip()
+            if suffix.isdigit():
+                used.add(int(suffix))
+        while next_num in used:
+            next_num += 1
+        return f"{prefix}{next_num}"
 
     def _remove_dock_ring_orbit(self):
         """Entfernt Orbit-Kreis und Vorschau-Punkt."""

--- a/fl_editor/main_window.py
+++ b/fl_editor/main_window.py
@@ -30902,6 +30902,11 @@ class MainWindow(QMainWindow):
             existing_bases=existing_bases if needs_base else None,
             pilots=pilots,
             voices=voices,
+            template_room_names_provider=lambda template_nick, gp=game_path: [
+                str(row.get("room", "")).strip()
+                for row in self._load_base_room_template_details(gp, template_nick)
+                if str(row.get("room", "")).strip()
+            ],
             needs_base=needs_base,
             default_faction=self._current_system_local_faction_ui_label(),
             ids_name_text=ring_ids_name_text,

--- a/tests/test_base_scaffolding.py
+++ b/tests/test_base_scaffolding.py
@@ -145,6 +145,44 @@ def test_normalize_room_navigation_replaces_non_virtual_exit_doors_only():
     assert "name = IDS_SPECIAL_VIRTUAL" in normalized
 
 
+def test_normalize_room_navigation_preserves_template_exit_order_and_appends_only_missing_targets():
+    content = (
+        "[Room_Info]\n"
+        "set_script = test\n"
+        "\n"
+        "[Hotspot]\n"
+        "name = IDS_HOTSPOT_PLANETSCAPE\n"
+        "behavior = ExitDoor\n"
+        "room_switch = Planetscape\n"
+        "\n"
+        "[Hotspot]\n"
+        "name = IDS_HOTSPOT_BAR\n"
+        "behavior = ExitDoor\n"
+        "room_switch = Bar\n"
+        "\n"
+        "[Hotspot]\n"
+        "name = IDS_HOTSPOT_COMMODITYTRADER_ROOM\n"
+        "behavior = ExitDoor\n"
+        "room_switch = Planetscape\n"
+        "set_virtual_room = Trader\n"
+        "\n"
+    )
+
+    normalized = normalize_room_navigation(
+        content,
+        "Planetscape",
+        ["Bar", "Planetscape", "Planetscape2"],
+        "Bar",
+    )
+    lines = normalized.splitlines()
+
+    assert normalized.index("name = IDS_HOTSPOT_PLANETSCAPE") < normalized.index("name = IDS_HOTSPOT_BAR")
+    assert "name = IDS_HOTSPOT_EXIT" not in normalized
+    assert lines.count("name = IDS_HOTSPOT_PLANETSCAPE") == 1
+    assert lines.count("name = IDS_HOTSPOT_BAR") == 1
+    assert "name = IDS_HOTSPOT_PLANETSCAPE2" in normalized
+
+
 def test_create_base_room_files_creates_and_reports_new_rooms(tmp_path: Path):
     results = create_base_room_files(
         rooms_dir=tmp_path,

--- a/tests/test_docking_ring_dialog.py
+++ b/tests/test_docking_ring_dialog.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from PySide6.QtCore import Qt
+
+from fl_editor.dialogs import DockingRingDialog
+
+
+def test_docking_ring_dialog_prefills_user_friendly_defaults_and_template_data(qapp):
+    dialog = DockingRingDialog(
+        None,
+        planet_nickname="li01_01",
+        base_nickname="li01_01_base",
+        loadouts=["docking_ring_li_01"],
+        factions=["li_n_grp - Liberty Navy"],
+        existing_bases=[("Template Base", "li01_02_base")],
+        pilots=["pilot_solar_easiest"],
+        voices=["atc_leg_f01a"],
+        needs_base=True,
+        default_faction="li_n_grp - Liberty Navy",
+        ids_name_text="Planet Manhattan Docking Ring",
+        strid_name_value=1234,
+    )
+    dialog.template_cb.setCurrentIndex(1)
+
+    payload = dialog.payload()
+
+    assert payload["nickname"] == "Dock_Ring_li01_01"
+    assert payload["ids_name"] == "Planet Manhattan Docking Ring"
+    assert payload["ids_info"] == "66141"
+    assert payload["base_nickname"] == "li01_01_base"
+    assert payload["strid_name"] == 1234
+    assert payload["rooms"] == ["Deck", "Bar", "Trader"]
+    assert payload["start_room"] == "Deck"
+    assert payload["template_base"] == "li01_02_base"
+    assert payload["create_fixture"] is False
+    assert dialog.faction_cb.currentText() == "li_n_grp - Liberty Navy"
+    assert dialog.voice_cb.currentText() == "atc_leg_m01"
+    assert dialog.faction_cb.completer() is not None
+    assert dialog.faction_cb.completer().filterMode() == Qt.MatchContains
+    assert dialog.template_cb.itemText(1) == "Template Base"
+    assert dialog.template_cb.itemData(1) == "li01_02_base"
+
+
+def test_docking_ring_dialog_allows_enabling_fixture_creation(qapp):
+    dialog = DockingRingDialog(
+        None,
+        planet_nickname="li01_01",
+        base_nickname="li01_01_base",
+        loadouts=["docking_ring_li_01"],
+        factions=["li_n_grp - Liberty Navy"],
+        needs_base=False,
+    )
+
+    dialog.create_fixture_cb.setChecked(True)
+
+    payload = dialog.payload()
+
+    assert payload["create_fixture"] is True

--- a/tests/test_docking_ring_dialog.py
+++ b/tests/test_docking_ring_dialog.py
@@ -33,6 +33,7 @@ def test_docking_ring_dialog_prefills_user_friendly_defaults_and_template_data(q
     assert payload["start_room"] == "Deck"
     assert payload["template_base"] == "li01_02_base"
     assert payload["create_fixture"] is False
+    assert payload["copy_template_npcs"] is True
     assert dialog.faction_cb.currentText() == "li_n_grp - Liberty Navy"
     assert dialog.voice_cb.currentText() == "atc_leg_m01"
     assert dialog.faction_cb.completer() is not None
@@ -56,6 +57,7 @@ def test_docking_ring_dialog_allows_enabling_fixture_creation(qapp):
     payload = dialog.payload()
 
     assert payload["create_fixture"] is True
+    assert payload["copy_template_npcs"] is False
 
 
 def test_docking_ring_dialog_template_selection_enables_template_rooms(qapp):
@@ -80,3 +82,24 @@ def test_docking_ring_dialog_template_selection_enables_template_rooms(qapp):
     assert dialog.room_checks["Planetscape2"].isChecked() is True
     assert dialog.room_checks["Deck"].isChecked() is False
     assert payload["rooms"] == ["Bar", "Planetscape", "Planetscape2"]
+    assert payload["start_room"] == "Planetscape"
+
+
+def test_docking_ring_dialog_prefers_cityscape_as_template_start_room(qapp):
+    dialog = DockingRingDialog(
+        None,
+        planet_nickname="li01_01",
+        base_nickname="li01_01_base",
+        loadouts=["docking_ring_li_01"],
+        factions=["li_n_grp - Liberty Navy"],
+        existing_bases=[("Houston", "li04_01_base")],
+        template_room_names_provider=lambda template_nick: ["Bar", "Trader", "Equipment", "ShipDealer", "Cityscape"] if template_nick == "li04_01_base" else [],
+        needs_base=True,
+    )
+
+    dialog.template_cb.setCurrentIndex(1)
+
+    payload = dialog.payload()
+
+    assert payload["rooms"] == ["Bar", "Trader", "Equipment", "ShipDealer", "Cityscape"]
+    assert payload["start_room"] == "Cityscape"

--- a/tests/test_docking_ring_dialog.py
+++ b/tests/test_docking_ring_dialog.py
@@ -56,3 +56,27 @@ def test_docking_ring_dialog_allows_enabling_fixture_creation(qapp):
     payload = dialog.payload()
 
     assert payload["create_fixture"] is True
+
+
+def test_docking_ring_dialog_template_selection_enables_template_rooms(qapp):
+    dialog = DockingRingDialog(
+        None,
+        planet_nickname="li01_01",
+        base_nickname="li01_01_base",
+        loadouts=["docking_ring_li_01"],
+        factions=["li_n_grp - Liberty Navy"],
+        existing_bases=[("Planet Pittsburgh", "li06_02_base")],
+        template_room_names_provider=lambda template_nick: ["Bar", "Planetscape", "Planetscape2"] if template_nick == "li06_02_base" else [],
+        needs_base=True,
+    )
+
+    dialog.template_cb.setCurrentIndex(1)
+
+    payload = dialog.payload()
+
+    assert "Planetscape" in dialog.room_checks
+    assert dialog.room_checks["Trader"].isChecked() is False
+    assert dialog.room_checks["Planetscape"].isChecked() is True
+    assert dialog.room_checks["Planetscape2"].isChecked() is True
+    assert dialog.room_checks["Deck"].isChecked() is False
+    assert payload["rooms"] == ["Bar", "Planetscape", "Planetscape2"]

--- a/tests/test_docking_ring_logic.py
+++ b/tests/test_docking_ring_logic.py
@@ -55,6 +55,7 @@ def test_build_docking_ring_payload_with_new_base_collects_room_data():
         "difficulty": 1,
         "ids_name": "123",
         "ids_info": "456",
+        "create_fixture": False,
         "base_nickname": "li01_01_base",
         "strid_name": 789,
         "rooms": ["Deck", "Bar"],
@@ -81,4 +82,5 @@ def test_build_docking_ring_payload_with_existing_base_uses_existing_nickname():
     )
 
     assert payload["base_nickname"] == "li01_existing_base"
+    assert payload["create_fixture"] is False
     assert "rooms" not in payload

--- a/tests/test_docking_ring_logic.py
+++ b/tests/test_docking_ring_logic.py
@@ -56,6 +56,7 @@ def test_build_docking_ring_payload_with_new_base_collects_room_data():
         "ids_name": "123",
         "ids_info": "456",
         "create_fixture": False,
+        "copy_template_npcs": True,
         "base_nickname": "li01_01_base",
         "strid_name": 789,
         "rooms": ["Deck", "Bar"],
@@ -83,4 +84,5 @@ def test_build_docking_ring_payload_with_existing_base_uses_existing_nickname():
 
     assert payload["base_nickname"] == "li01_existing_base"
     assert payload["create_fixture"] is False
+    assert payload["copy_template_npcs"] is True
     assert "rooms" not in payload

--- a/tests/test_main_window_smoke.py
+++ b/tests/test_main_window_smoke.py
@@ -6735,6 +6735,122 @@ def test_attach_docking_ring_keeps_object_clicks_enabled(main_window, monkeypatc
     assert main_window.view._allow_item_clicks_in_placement is True
 
 
+def test_dock_ring_planet_dialog_prefills_system_base_name_and_planet_name(main_window, monkeypatch):
+    class _RejectedDockingDialog:
+        captured: dict[str, object] = {}
+
+        def __init__(self, *args, **kwargs):
+            type(self).captured = dict(kwargs)
+
+        def exec(self):
+            return QDialog.Rejected
+
+    main_window._filepath = "/tmp/Li06.ini"
+    main_window._pending_dock_ring = {"step": 1, "game_path": "C:/Freelancer"}
+    main_window._uni_sections = [
+        ("Base", [("nickname", "Ew06_02_Base"), ("strid_name", "111")]),
+        ("Base", [("nickname", "li01_01_base"), ("strid_name", "222")]),
+    ]
+    monkeypatch.setattr(main_window, "_scan_pilots", lambda _game_path: ["pilot_solar_easiest"])
+    monkeypatch.setattr(main_window, "_scan_voices", lambda _game_path: ["atc_leg_m01"])
+    monkeypatch.setattr(main_window, "_current_system_local_faction_ui_label", lambda: "li_n_grp - Liberty Navy")
+    monkeypatch.setattr(main_window, "_display_name_from_ids_name", lambda ids: "Planet Manhattan" if str(ids) == "1234" else "")
+    monkeypatch.setattr(main_window_module, "DockingRingDialog", _RejectedDockingDialog)
+    main_window.loadout_cb.clear()
+    main_window.loadout_cb.addItem("docking_ring_li_01")
+    main_window.faction_cb.clear()
+    main_window.faction_cb.addItem("li_n_grp - Liberty Navy")
+
+    planet = SolarObject(
+        {
+            "nickname": "li06_01_planet",
+            "archetype": "planet_earth",
+            "pos": "0, 0, 0",
+            "_entries": [
+                ("nickname", "li06_01_planet"),
+                ("archetype", "planet_earth"),
+                ("ids_name", "1234"),
+                ("pos", "0, 0, 0"),
+            ],
+        },
+        1.0,
+    )
+
+    main_window._on_dock_ring_planet_selected(planet)
+
+    captured = _RejectedDockingDialog.captured
+    assert captured["base_nickname"] == "Li06_01_Base"
+    assert captured["ids_name_text"] == "Planet Manhattan Docking Ring"
+    assert captured["ids_info_value"] == "66141"
+    assert captured["strid_name_value"] == 1234
+    assert captured["existing_bases"] == [
+        ("Ew06_02_Base", "Ew06_02_Base"),
+        ("li01_01_base", "li01_01_base"),
+    ]
+
+
+def test_dock_ring_orbit_click_converts_name_text_to_ids_name(main_window, monkeypatch):
+    added: list[dict[str, object]] = []
+
+    main_window._filepath = "/tmp/Li06.ini"
+    main_window._pending_dock_ring = {
+        "step": 2,
+        "planet_scene_x": 0.0,
+        "planet_scene_y": 0.0,
+        "orbit_scene": 1000.0,
+        "orbit_world": 1000.0,
+        "planet_world": (0.0, 0.0, 0.0),
+        "dialog_data": {
+            "nickname": "Dock_Ring_li06_01_planet",
+            "ids_name": "Planet Manhattan Docking Ring",
+            "ids_info": "66141",
+            "archetype": "dock_ring",
+            "loadout": "docking_ring_li_01",
+            "faction": "li_n_grp - Liberty Navy",
+            "voice": "atc_leg_m01",
+            "pilot": "pilot_solar_easiest",
+            "difficulty": 1,
+            "costume": "robot_body_A",
+            "create_fixture": True,
+        },
+        "needs_base": False,
+        "game_path": "C:/Freelancer",
+        "sys_nick": "Li06",
+        "base_nick": "Li06_01_Base",
+        "planet_item": SolarObject({"nickname": "planet", "_entries": []}, 1.0),
+        "planet_nick": "li06_01_planet",
+    }
+
+    monkeypatch.setattr(main_window, "_has_ids_resource_toolchain", lambda: True)
+    monkeypatch.setattr(main_window, "_ensure_ids_name_in_user_dll", lambda current, text: "345678")
+    monkeypatch.setattr(main_window, "_faction_from_ui", lambda value: "li_n_grp")
+    monkeypatch.setattr(main_window, "_remove_dock_ring_orbit", lambda: None)
+    monkeypatch.setattr(main_window, "_set_dirty", lambda _dirty: None)
+    monkeypatch.setattr(main_window, "_write_to_file", lambda reload=False: None)
+    monkeypatch.setattr(main_window, "_set_placement_mode", lambda *args, **kwargs: None)
+    monkeypatch.setattr(main_window, "_add_object_from_entries", lambda entries, section_name: added.append({"entries": list(entries), "section_name": section_name}))
+    monkeypatch.setattr(main_window_module.QMessageBox, "information", staticmethod(lambda *args, **kwargs: QMessageBox.Ok))
+
+    main_window._on_dock_ring_orbit_click(QPointF(1000.0, 0.0))
+
+    ring_entries = added[0]["entries"]
+    fixture_entries = added[1]["entries"]
+
+    assert added[0]["section_name"] == "Object"
+    assert ("ids_name", "345678") in ring_entries
+    assert ("ids_info", "66141") in ring_entries
+    assert ("space_costume", ", robot_body_A") in ring_entries
+    assert added[1]["section_name"] == "Object"
+    assert ("nickname", "Li06_docking_fixture_1") in fixture_entries
+    assert ("ids_name", "261166") in fixture_entries
+    assert ("ids_info", "66489") in fixture_entries
+    assert ("Archetype", "docking_fixture") in fixture_entries
+    assert ("dock_with", "Li06_01_Base") in fixture_entries
+    assert ("base", "Li06_01_Base") in fixture_entries
+    assert ("reputation", "li_n_grp") in fixture_entries
+    assert main_window._pending_dock_ring is None
+
+
 def test_select_object_in_ring_attach_mode_opens_ring_dialog(main_window, monkeypatch):
     main_window._filepath = "/tmp/test_system.ini"
     obj = SolarObject(

--- a/tests/test_main_window_smoke.py
+++ b/tests/test_main_window_smoke.py
@@ -5674,16 +5674,22 @@ def test_normalize_base_object_link_entries_keeps_planet_base_but_removes_dock_w
         ("archetype", "planet_manhattan"),
         ("base", "Li01_01_Base"),
         ("dock_with", "Li01_01_Base"),
+        ("pilot", "pilot_solar_easiest"),
+        ("space_costume", "benchmark_male_head, benchmark_male_body"),
     ]
 
     normalized = main_window._normalize_base_object_link_entries(
         entries,
         archetype="planet_manhattan",
         base_nickname="Li01_01_Base",
+        reputation="li_p_grp",
     )
 
     assert ("base", "Li01_01_Base") in normalized
+    assert ("reputation", "li_p_grp") in normalized
     assert not any(str(key).strip().lower() == "dock_with" for key, _value in normalized)
+    assert not any(str(key).strip().lower() == "pilot" for key, _value in normalized)
+    assert not any(str(key).strip().lower() == "space_costume" for key, _value in normalized)
 
 
 def test_normalize_base_object_link_entries_keeps_dock_ring_dock_with_but_removes_base(main_window):
@@ -6915,6 +6921,87 @@ def test_dock_ring_orbit_click_copies_template_npcs_for_new_base(main_window, mo
     assert len(npc_rows) == 1
     assert npc_rows[0]["nickname"] == "li06_03_base_bar_npc_01"
     assert npc_rows[0]["name_text"] == "Bartender"
+
+
+def test_dock_ring_orbit_click_normalizes_planetary_base_object_entries(main_window, monkeypatch):
+    planet_entries = [
+        ("nickname", "LI06_planet_007"),
+        ("archetype", "planet_crater_1000"),
+        ("ids_name", "524309"),
+        ("pilot", "pilot_solar_easiest"),
+        ("space_costume", "benchmark_male_head, benchmark_male_body"),
+    ]
+    planet = SolarObject(
+        {
+            "nickname": "LI06_planet_007",
+            "archetype": "planet_crater_1000",
+            "_entries": list(planet_entries),
+        },
+        1.0,
+    )
+
+    main_window._filepath = "/tmp/Li06.ini"
+    main_window._sections = [("Object", list(planet_entries))]
+    main_window._pending_dock_ring = {
+        "step": 2,
+        "planet_scene_x": 0.0,
+        "planet_scene_y": 0.0,
+        "orbit_scene": 1000.0,
+        "orbit_world": 1000.0,
+        "planet_world": (0.0, 0.0, 0.0),
+        "dialog_data": {
+            "nickname": "Dock_Ring_LI06_planet_007",
+            "ids_name": "Planet Manhattan Docking Ring",
+            "ids_info": "66141",
+            "archetype": "dock_ring",
+            "loadout": "docking_ring_li_01",
+            "faction": "li_n_grp - Liberty Navy",
+            "voice": "atc_leg_m01",
+            "pilot": "pilot_solar_easiest",
+            "difficulty": 1,
+            "costume": "robot_body_A",
+            "rooms": ["Bar"],
+            "start_room": "Bar",
+            "price_variance": 0.15,
+            "base_nickname": "LI06_07_Base",
+            "strid_name": 524309,
+        },
+        "needs_base": True,
+        "game_path": "C:/Freelancer",
+        "sys_nick": "LI06",
+        "base_nick": "LI06_07_Base",
+        "planet_item": planet,
+        "planet_nick": "LI06_planet_007",
+    }
+
+    monkeypatch.setattr(main_window, "_has_ids_resource_toolchain", lambda: True)
+    monkeypatch.setattr(main_window, "_ensure_ids_name_in_user_dll", lambda current, text: "345678")
+    monkeypatch.setattr(main_window, "_faction_from_ui", lambda value: "li_n_grp")
+    monkeypatch.setattr(main_window, "_normalize_reputation_value", lambda value: "li_n_grp")
+    monkeypatch.setattr(main_window, "_remove_dock_ring_orbit", lambda: None)
+    monkeypatch.setattr(main_window, "_set_dirty", lambda _dirty: None)
+    monkeypatch.setattr(main_window, "_write_to_file", lambda reload=False: None)
+    monkeypatch.setattr(main_window, "_set_placement_mode", lambda *args, **kwargs: None)
+    monkeypatch.setattr(main_window, "_load_template_rooms", lambda game_path, template_base: {})
+    monkeypatch.setattr(main_window, "_generate_room_ini", lambda room_name, rooms, start_room: f"[Room]\nnickname = {room_name}\n")
+    monkeypatch.setattr(main_window, "_adapt_template_room", lambda content, new_base_nick, rooms: content)
+    monkeypatch.setattr(main_window, "_ensure_mbase_entry_for_base", lambda **kwargs: (False, ""))
+    monkeypatch.setattr(main_window, "_find_universe_ini_write", lambda _game_path: None)
+    monkeypatch.setattr(main_window, "_add_object_from_entries", lambda entries, section_name: None)
+    monkeypatch.setattr(main_window_module.QMessageBox, "information", staticmethod(lambda *args, **kwargs: QMessageBox.Ok))
+
+    main_window._on_dock_ring_orbit_click(QPointF(1000.0, 0.0))
+
+    normalized_entries = planet.data["_entries"]
+    section_entries = main_window._sections[0][1]
+
+    assert ("base", "LI06_07_Base") in normalized_entries
+    assert ("reputation", "li_n_grp") in normalized_entries
+    assert not any(str(key).strip().lower() == "dock_with" for key, _value in normalized_entries)
+    assert not any(str(key).strip().lower() == "pilot" for key, _value in normalized_entries)
+    assert not any(str(key).strip().lower() == "space_costume" for key, _value in normalized_entries)
+    assert ("reputation", "li_n_grp") in section_entries
+    assert not any(str(key).strip().lower() == "pilot" for key, _value in section_entries)
 
 
 def test_select_object_in_ring_attach_mode_opens_ring_dialog(main_window, monkeypatch):

--- a/tests/test_main_window_smoke.py
+++ b/tests/test_main_window_smoke.py
@@ -6851,6 +6851,72 @@ def test_dock_ring_orbit_click_converts_name_text_to_ids_name(main_window, monke
     assert main_window._pending_dock_ring is None
 
 
+def test_dock_ring_orbit_click_copies_template_npcs_for_new_base(main_window, monkeypatch):
+    copied_npcs: dict[str, object] = {}
+
+    main_window._filepath = "/tmp/Li06.ini"
+    main_window._sections = []
+    main_window._pending_dock_ring = {
+        "step": 2,
+        "planet_scene_x": 0.0,
+        "planet_scene_y": 0.0,
+        "orbit_scene": 1000.0,
+        "orbit_world": 1000.0,
+        "planet_world": (0.0, 0.0, 0.0),
+        "dialog_data": {
+            "nickname": "Dock_Ring_li06_01_planet",
+            "ids_name": "Planet Manhattan Docking Ring",
+            "ids_info": "66141",
+            "archetype": "dock_ring",
+            "loadout": "docking_ring_li_01",
+            "faction": "li_n_grp - Liberty Navy",
+            "voice": "atc_leg_m01",
+            "pilot": "pilot_solar_easiest",
+            "difficulty": 1,
+            "costume": "robot_body_A",
+            "template_base": "li01_02_base",
+            "copy_template_npcs": True,
+            "rooms": ["Bar", "Planetscape"],
+            "start_room": "Bar",
+            "price_variance": 0.15,
+            "base_nickname": "Li06_03_Base",
+        },
+        "needs_base": True,
+        "game_path": "C:/Freelancer",
+        "sys_nick": "Li06",
+        "base_nick": "Li06_03_Base",
+        "planet_item": SolarObject({"nickname": "planet", "_entries": []}, 1.0),
+        "planet_nick": "li06_01_planet",
+    }
+
+    monkeypatch.setattr(main_window, "_has_ids_resource_toolchain", lambda: True)
+    monkeypatch.setattr(main_window, "_ensure_ids_name_in_user_dll", lambda current, text: "345678")
+    monkeypatch.setattr(main_window, "_faction_from_ui", lambda value: "li_n_grp")
+    monkeypatch.setattr(main_window, "_normalize_reputation_value", lambda value: "li_n_grp")
+    monkeypatch.setattr(main_window, "_remove_dock_ring_orbit", lambda: None)
+    monkeypatch.setattr(main_window, "_set_dirty", lambda _dirty: None)
+    monkeypatch.setattr(main_window, "_write_to_file", lambda reload=False: None)
+    monkeypatch.setattr(main_window, "_set_placement_mode", lambda *args, **kwargs: None)
+    monkeypatch.setattr(main_window, "_load_template_rooms", lambda game_path, template_base: {})
+    monkeypatch.setattr(main_window, "_generate_room_ini", lambda room_name, rooms, start_room: f"[Room]\nnickname = {room_name}\n")
+    monkeypatch.setattr(main_window, "_adapt_template_room", lambda content, new_base_nick, rooms: content)
+    monkeypatch.setattr(main_window, "_ensure_mbase_entry_for_base", lambda **kwargs: (False, ""))
+    monkeypatch.setattr(main_window, "_load_base_template_room_npcs", lambda game_path, template_base: {"bar": [{"nickname": "li0102_fix_bartender", "name_text": "Bartender"}]})
+    monkeypatch.setattr(main_window, "_apply_room_npcs_to_base", lambda **kwargs: copied_npcs.update(kwargs) or 1)
+    monkeypatch.setattr(main_window, "_find_universe_ini_write", lambda _game_path: None)
+    monkeypatch.setattr(main_window, "_add_object_from_entries", lambda entries, section_name: None)
+    monkeypatch.setattr(main_window_module.QMessageBox, "information", staticmethod(lambda *args, **kwargs: QMessageBox.Ok))
+
+    main_window._on_dock_ring_orbit_click(QPointF(1000.0, 0.0))
+
+    assert copied_npcs["base_nick"] == "Li06_03_Base"
+    assert copied_npcs["valid_rooms"] == ["Bar", "Planetscape"]
+    npc_rows = copied_npcs["room_customizations"]["bar"]["npc_rows"]
+    assert len(npc_rows) == 1
+    assert npc_rows[0]["nickname"] == "li06_03_base_bar_npc_01"
+    assert npc_rows[0]["name_text"] == "Bartender"
+
+
 def test_select_object_in_ring_attach_mode_opens_ring_dialog(main_window, monkeypatch):
     main_window._filepath = "/tmp/test_system.ini"
     obj = SolarObject(


### PR DESCRIPTION
## Summary
- fix docking ring creation defaults and fixture generation
- copy template rooms and NPCs into newly created docking ring bases
- normalize planetary base links so new planet bases keep vanilla-style name visibility

## Testing
- `.\.venv\Scripts\python.exe -m pytest tests\test_docking_ring_logic.py tests\test_docking_ring_dialog.py -q`
- `.\.venv\Scripts\python.exe -m pytest tests\test_base_scaffolding.py tests\test_docking_ring_dialog.py -q`
- `.\.venv\Scripts\python.exe -m pytest tests\test_main_window_smoke.py -k "normalize_base_object_link_entries or dock_ring_orbit_click" -q`

Closes #19