### PR TITLE
Show INI section headers in 2D object editor

### DIFF
--- a/fl_editor/models.py
+++ b/fl_editor/models.py
@@ -260,13 +260,17 @@ class ZoneItem(QGraphicsItem):
     # ------------------------------------------------------------------
     def raw_text(self) -> str:
         """Einträge als editierbaren Text zurückgeben."""
-        return "\n".join(f"{k} = {v}" for k, v in self.data.get("_entries", []))
+        lines = ["[Zone]"]
+        lines.extend(f"{k} = {v}" for k, v in self.data.get("_entries", []))
+        return "\n".join(lines)
 
     def apply_text(self, text: str):
         """Editierten INI-Text auf dieses Zonenobjekt anwenden."""
         new_entries: list[tuple[str, str]] = []
         for line in text.splitlines():
             line = line.strip()
+            if not line or (line.startswith("[") and line.endswith("]")):
+                continue
             if "=" in line:
                 k, _, v = line.partition("=")
                 new_entries.append((k.strip(), v.strip()))
@@ -562,12 +566,16 @@ class SolarObject(QGraphicsEllipseItem):
     #  Daten-Serialisierung
     # ------------------------------------------------------------------
     def raw_text(self) -> str:
-        return "\n".join(f"{k} = {v}" for k, v in self.data.get("_entries", []))
+        lines = ["[Object]"]
+        lines.extend(f"{k} = {v}" for k, v in self.data.get("_entries", []))
+        return "\n".join(lines)
 
     def apply_text(self, text: str):
         new_entries: list[tuple[str, str]] = []
         for line in text.splitlines():
             line = line.strip()
+            if not line or (line.startswith("[") and line.endswith("]")):
+                continue
             if "=" in line:
                 k, _, v = line.partition("=")
                 new_entries.append((k.strip(), v.strip()))

--- a/tests/test_main_window_smoke.py
+++ b/tests/test_main_window_smoke.py
@@ -5668,6 +5668,84 @@ def test_show_selected_3d_preview_uses_multipart_base_preview_branch(main_window
     assert calls == [("li01_01_base_obj", "Li01_01_Base")]
 
 
+def test_solar_object_raw_text_includes_object_header(qapp):
+    obj = SolarObject(
+        {
+            "nickname": "li01_01",
+            "archetype": "planet_desored_1500",
+            "_entries": [
+                ("nickname", "li01_01"),
+                ("archetype", "planet_desored_1500"),
+            ],
+        },
+        1.0,
+    )
+
+    assert obj.raw_text() == "[Object]\nnickname = li01_01\narchetype = planet_desored_1500"
+
+
+def test_zone_item_raw_text_includes_zone_header(qapp):
+    zone = ZoneItem(
+        {
+            "nickname": "zone_li01_test",
+            "shape": "SPHERE",
+            "size": "1000",
+            "_entries": [
+                ("nickname", "zone_li01_test"),
+                ("shape", "SPHERE"),
+                ("size", "1000"),
+            ],
+        },
+        1.0,
+    )
+
+    assert zone.raw_text() == "[Zone]\nnickname = zone_li01_test\nshape = SPHERE\nsize = 1000"
+
+
+def test_solar_object_apply_text_ignores_object_header(qapp):
+    obj = SolarObject(
+        {
+            "nickname": "old_name",
+            "archetype": "space_police01",
+            "_entries": [("nickname", "old_name"), ("archetype", "space_police01")],
+        },
+        1.0,
+    )
+
+    obj.apply_text("[Object]\nnickname = new_name\narchetype = station\nrotate = 0, 90, 0")
+
+    assert obj.data["_entries"] == [
+        ("nickname", "new_name"),
+        ("archetype", "station"),
+        ("rotate", "0, 90, 0"),
+    ]
+    assert obj.nickname == "new_name"
+
+
+def test_zone_item_apply_text_ignores_zone_header(qapp):
+    zone = ZoneItem(
+        {
+            "nickname": "zone_old",
+            "shape": "SPHERE",
+            "size": "1000",
+            "_entries": [
+                ("nickname", "zone_old"),
+                ("shape", "SPHERE"),
+                ("size", "1000"),
+            ],
+        },
+        1.0,
+    )
+
+    zone.apply_text("[Zone]\nnickname = zone_new\nshape = BOX\nsize = 100, 100, 100")
+
+    assert zone.data["_entries"] == [
+        ("nickname", "zone_new"),
+        ("shape", "BOX"),
+        ("size", "100, 100, 100"),
+    ]
+
+
 def test_normalize_base_object_link_entries_keeps_planet_base_but_removes_dock_with(main_window):
     entries = [
         ("nickname", "Li01_01"),


### PR DESCRIPTION
## Summary
- include `[Object]` and `[Zone]` section headers in the 2D system editor text view
- keep object and zone editing compatible by ignoring section headers on apply
- add regression coverage for header rendering and apply parsing

## Testing
- `.\.venv\Scripts\python.exe -m pytest tests\test_main_window_smoke.py -k raw_text`
- `.\.venv\Scripts\python.exe -m pytest tests\test_main_window_smoke.py -k apply_text_ignores`
- `.\.venv\Scripts\python.exe -m pytest tests\test_top_view_icons.py tests\test_zone_item_rotation.py -q`

Closes #20