### PR TITLE
Fix hover artifacts in 2D system and universe views

### DIFF
--- a/fl_editor/models.py
+++ b/fl_editor/models.py
@@ -311,6 +311,7 @@ class SolarObject(QGraphicsEllipseItem):
     _TOP_VIEW_ICON_RADIUS_BOOST = 1.85
     _TOP_VIEW_ICON_MIN_RADIUS = 5.5
     _MIN_INTERACTIVE_RADIUS = 1.6
+    _HOVER_OUTLINE_PADDING = 3.0
 
     # Farb + GrößenTabelle  → (farbe, radius, z-value, schriftgröße)
     _STYLES: list[tuple[list[str], QColor, float, int, float]] = [
@@ -537,6 +538,13 @@ class SolarObject(QGraphicsEllipseItem):
         self.set_view_zoom(self._last_zoom_factor)
         self.update()
 
+    def _hover_pen(self) -> QPen:
+        pen = QPen(QColor(255, 215, 96, 230), 2.0)
+        pen.setCosmetic(True)
+        pen.setJoinStyle(Qt.RoundJoin)
+        pen.setCapStyle(Qt.RoundCap)
+        return pen
+
     # ------------------------------------------------------------------
     #  Freelancer-Position  (aktuell auf dem Canvas)
     # ------------------------------------------------------------------
@@ -637,10 +645,18 @@ class SolarObject(QGraphicsEllipseItem):
         self.update()
         super().hoverLeaveEvent(event)
 
+    def boundingRect(self) -> QRectF:
+        rect = QRectF(self.rect())
+        if rect.isNull():
+            return super().boundingRect()
+        pad = float(self._HOVER_OUTLINE_PADDING)
+        return rect.adjusted(-pad, -pad, pad, pad)
+
     def paint(self, painter, option, widget=None):
         if self._top_view_icon is not None and not self._top_view_icon.isNull():
             rect = self.rect()
             painter.save()
+            painter.setRenderHint(QPainter.Antialiasing, True)
             painter.setRenderHint(QPainter.SmoothPixmapTransform, True)
             target_rect = rect.toRect()
             if target_rect.width() <= 0 or target_rect.height() <= 0:
@@ -650,20 +666,19 @@ class SolarObject(QGraphicsEllipseItem):
             painter.setBrush(Qt.NoBrush)
             painter.drawEllipse(rect)
             if self._hovered:
-                hover_pen = QPen(QColor(255, 215, 96, 230), max(2.0, rect.width() * 0.06))
-                painter.setPen(hover_pen)
-                painter.drawEllipse(rect.adjusted(-2.0, -2.0, 2.0, 2.0))
+                painter.setPen(self._hover_pen())
+                painter.drawEllipse(rect)
             painter.restore()
             return
+        painter.save()
+        painter.setRenderHint(QPainter.Antialiasing, True)
         super().paint(painter, option, widget)
         if self._hovered:
-            painter.save()
             rect = self.rect()
-            hover_pen = QPen(QColor(255, 215, 96, 230), max(2.0, rect.width() * 0.06))
-            painter.setPen(hover_pen)
+            painter.setPen(self._hover_pen())
             painter.setBrush(Qt.NoBrush)
-            painter.drawEllipse(rect.adjusted(-2.0, -2.0, 2.0, 2.0))
-            painter.restore()
+            painter.drawEllipse(rect)
+        painter.restore()
 
 
 # ══════════════════════════════════════════════════════════════════════
@@ -760,7 +775,7 @@ class UniverseSystem(SolarObject):
         super().paint(painter, option, widget)
 
     def boundingRect(self) -> QRectF:
-        h = self._uni_halo + 2
+        h = self._uni_halo + max(2.0, float(self._HOVER_OUTLINE_PADDING))
         return QRectF(-h, -h, h * 2, h * 2)
         if self.label:
             self.label.setFont(QFont("Sans", 8))

--- a/tests/test_view_2d.py
+++ b/tests/test_view_2d.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from PySide6.QtCore import QPoint, QPointF, Qt
 import pytest
 
-from fl_editor.models import SolarObject
+from fl_editor.models import SolarObject, UniverseSystem
 from fl_editor.view_2d import SystemView
 
 
@@ -63,3 +63,36 @@ def test_placement_mode_can_still_select_objects_when_allowed(qapp, monkeypatch)
 
     assert selected == [obj]
     assert background == []
+
+
+def test_solar_object_hover_pen_is_cosmetic_and_bounding_rect_has_padding(qapp):
+    obj = SolarObject(
+        {
+            "nickname": "test_station",
+            "archetype": "space_police01",
+            "pos": "0,0,0",
+            "_entries": [("nickname", "test_station"), ("archetype", "space_police01"), ("pos", "0,0,0")],
+        },
+        1.0,
+    )
+
+    pen = obj._hover_pen()
+    rect = obj.rect()
+    bounds = obj.boundingRect()
+
+    assert pen.isCosmetic()
+    assert pen.widthF() == pytest.approx(2.0)
+    assert bounds.left() < rect.left()
+    assert bounds.right() > rect.right()
+    assert bounds.top() < rect.top()
+    assert bounds.bottom() > rect.bottom()
+
+
+def test_universe_system_bounding_rect_includes_halo_and_hover_padding(qapp):
+    system = UniverseSystem("Li01", "Universe\\Systems\\LI01\\LI01.ini", (0.0, 0.0), 1.0)
+
+    bounds = system.boundingRect()
+
+    assert bounds.width() > system.rect().width()
+    assert bounds.height() > system.rect().height()
+    assert bounds.left() <= -(system._uni_halo + system._HOVER_OUTLINE_PADDING)


### PR DESCRIPTION
## Summary
- use a cosmetic hover outline so hover rendering stays stable while zooming
- expand object and universe bounding rects so hover/halo painting is not clipped
- add regression coverage for hover pen and view bounding behavior

## Testing
- `.\.venv\Scripts\python.exe -m pytest tests\test_view_2d.py -q`
- `.\.venv\Scripts\python.exe -m pytest tests\test_top_view_icons.py tests\test_zone_item_rotation.py -q`

Closes #25