### PR TITLE
Fix center tab dragging and suppress reloads while reordering

### DIFF
--- a/fl_editor/main_window.py
+++ b/fl_editor/main_window.py
@@ -121,6 +121,49 @@ from .base_scaffolding import (
     write_base_ini,
     write_room_ini,
 )
+
+
+class CenterTabBar(QTabBar):
+    """Tab bar that exposes whether a tab reorder drag is currently active."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._drag_start_pos: QPointF | None = None
+        self._drag_start_index = -1
+        self._reordering = False
+
+    def is_reordering(self) -> bool:
+        return bool(self._reordering)
+
+    def mousePressEvent(self, event):
+        if event.button() == Qt.LeftButton:
+            self._drag_start_pos = QPointF(event.position())
+            self._drag_start_index = int(self.tabAt(event.position().toPoint()))
+            self._reordering = False
+        super().mousePressEvent(event)
+
+    def mouseMoveEvent(self, event):
+        if (
+            self._drag_start_pos is not None
+            and self._drag_start_index >= 0
+            and bool(event.buttons() & Qt.LeftButton)
+        ):
+            if (event.position() - self._drag_start_pos).manhattanLength() >= QApplication.startDragDistance():
+                self._reordering = True
+        super().mouseMoveEvent(event)
+
+    def mouseReleaseEvent(self, event):
+        was_reordering = bool(self._reordering)
+        super().mouseReleaseEvent(event)
+        self._drag_start_pos = None
+        self._drag_start_index = -1
+        if was_reordering:
+            QTimer.singleShot(0, self._finish_reordering)
+        else:
+            self._reordering = False
+
+    def _finish_reordering(self):
+        self._reordering = False
 from .async_ui_runtime import start_async_view_load
 from .base_deletion import (
     base_nickname_from_object_entries,
@@ -6109,10 +6152,12 @@ class MainWindow(QMainWindow):
         center_layout = QVBoxLayout(center_host)
         center_layout.setContentsMargins(0, 0, 0, 0)
         center_layout.setSpacing(0)
-        self.center_tab_bar = QTabBar(center_host)
+        self.center_tab_bar = CenterTabBar(center_host)
         self.center_tab_bar.setDrawBase(False)
         self.center_tab_bar.setExpanding(False)
         self.center_tab_bar.setMovable(True)
+        if hasattr(self.center_tab_bar, "setChangeCurrentOnDrag"):
+            self.center_tab_bar.setChangeCurrentOnDrag(False)
         self.center_tab_bar.setTabsClosable(True)
         self.center_tab_bar.setContextMenuPolicy(Qt.CustomContextMenu)
         self.center_tab_bar.currentChanged.connect(self._on_center_tab_changed)

--- a/fl_editor/system_tab_runtime.py
+++ b/fl_editor/system_tab_runtime.py
@@ -83,6 +83,11 @@ def open_system_tab(window: Any, path: str, new_tab: bool = False) -> None:
 def on_center_tab_changed(window: Any, index: int) -> None:
     if window._center_tab_syncing or not hasattr(window, "center_stack"):
         return
+    bar = getattr(window, "center_tab_bar", None)
+    if bar is not None:
+        is_reordering = getattr(bar, "is_reordering", None)
+        if callable(is_reordering) and bool(is_reordering()):
+            return
     if index < 0 or index >= len(window._center_tab_specs):
         return
     spec = window._center_tab_specs[index]

--- a/tests/test_main_window_smoke.py
+++ b/tests/test_main_window_smoke.py
@@ -74,6 +74,32 @@ def test_main_window_starts_with_core_navigation(main_window):
     assert main_window.nav_savegame_btn.text()
 
 
+def test_center_tab_bar_disables_change_current_on_drag_when_supported(main_window):
+    bar = main_window.center_tab_bar
+
+    if not hasattr(bar, "changeCurrentOnDrag"):
+        pytest.skip("Qt build does not expose changeCurrentOnDrag")
+
+    assert bar.changeCurrentOnDrag() is False
+
+
+def test_on_center_tab_changed_ignores_changes_while_tab_reorder_drag_is_active(main_window, monkeypatch):
+    calls: list[str] = []
+
+    main_window._center_tab_specs = [
+        {"key": "mods", "widget": main_window.mod_manager_page, "closable": False},
+        {"key": "trade", "widget": main_window.trade_routes_page, "closable": False},
+    ]
+    main_window._center_current_tab_key = "mods"
+    monkeypatch.setattr(main_window.center_tab_bar, "is_reordering", lambda: True)
+    monkeypatch.setattr(main_window, "_open_trade_routes_view", lambda: calls.append("trade"))
+    monkeypatch.setattr(main_window, "_center_sync_tab_bar", lambda: calls.append("sync"))
+
+    main_window._on_center_tab_changed(1)
+
+    assert calls == []
+
+
 def test_main_window_size_hints_are_clamped_to_screen(main_window, monkeypatch):
     monkeypatch.setattr(
         main_window_module.QApplication,


### PR DESCRIPTION
## Summary
- add a dedicated center tab bar that tracks active reordering drags
- ignore `currentChanged` tab-switch handling while tabs are being reordered
- keep drag behavior stable across multiple tab positions without reloading tab contents

## Testing
- `.\.venv\Scripts\python.exe -m pytest tests\test_main_window_smoke.py -k "center_tab_bar_disables_change_current_on_drag_when_supported or ignores_changes_while_tab_reorder_drag_is_active or starts_with_core_navigation" -q`

Closes #28