### PR TITLE
Add editable planet ids_info creation in solar dialog

### DIFF
--- a/fl_editor/dialogs.py
+++ b/fl_editor/dialogs.py
@@ -2173,6 +2173,8 @@ class SolarCreationDialog(QDialog):
         stars: list[str] | None = None,
         default_star: str = "med_white_sun",
         enable_planet_ring: bool = False,
+        ids_info_text: str = "",
+        ids_info_text_provider=None,
     ):
         super().__init__(parent)
         self.setWindowTitle(title)
@@ -2180,6 +2182,8 @@ class SolarCreationDialog(QDialog):
         self._planet_prefill_enabled = bool(enable_planet_ring)
         self._default_radius = int(default_radius)
         self._default_atmosphere_range = 2000
+        self._ids_info_text_provider = ids_info_text_provider
+        self._last_ids_info_template_text = str(ids_info_text or "").strip()
         layout = QFormLayout(self)
         self.star_cb = None
         self.atmo_spin = None
@@ -2190,6 +2194,13 @@ class SolarCreationDialog(QDialog):
         self.ids_name_edit = QLineEdit()
         self.ids_name_edit.setPlaceholderText("Ingame Name (optional)")
         layout.addRow("Ingame Name:", self.ids_name_edit)
+
+        self.ids_info_edit = QTextEdit()
+        self.ids_info_edit.setMinimumHeight(120)
+        self.ids_info_edit.setLineWrapMode(QTextEdit.WidgetWidth)
+        self.ids_info_edit.setPlaceholderText("Info text / Infocard text (optional)")
+        self.ids_info_edit.setPlainText(self._last_ids_info_template_text)
+        layout.addRow("ids_info Text:", self.ids_info_edit)
 
         self.arch_cb = QComboBox()
         self.arch_cb.setEditable(True)
@@ -2255,6 +2266,16 @@ class SolarCreationDialog(QDialog):
         return value if value > 0 else None
 
     def _on_archetype_changed(self, archetype: str) -> None:
+        if callable(self._ids_info_text_provider):
+            try:
+                template_text = str(self._ids_info_text_provider(archetype) or "").strip()
+            except Exception:
+                template_text = ""
+            if template_text != self._last_ids_info_template_text:
+                current = str(self.ids_info_edit.toPlainText() or "").strip()
+                if current == self._last_ids_info_template_text or not current:
+                    self.ids_info_edit.setPlainText(template_text)
+                self._last_ids_info_template_text = template_text
         if not self._planet_prefill_enabled:
             return
         size = self._planet_size_from_archetype(archetype)
@@ -2276,6 +2297,7 @@ class SolarCreationDialog(QDialog):
         return build_solar_creation_payload(
             nickname=self.nick_edit.text(),
             ids_name_text=self.ids_name_edit.text(),
+            ids_info_text=self.ids_info_edit.toPlainText(),
             archetype=self.arch_cb.currentText(),
             burn_color=self._burn_rgb,
             radius=self.radius_spin.value(),

--- a/fl_editor/main_window.py
+++ b/fl_editor/main_window.py
@@ -24839,6 +24839,7 @@ class MainWindow(QMainWindow):
             self, tr("dlg.planet_create"), planet_arches,
             default_radius=1500, default_damage=200000,
             enable_planet_ring=True,
+            ids_info_text_provider=lambda archetype, gp=self._primary_game_path(): self._planet_ids_info_template_text(gp, archetype),
         )
         dlg.nick_edit.setText(
             self._suggest_system_scoped_name("planet", [o.nickname for o in self._objects])
@@ -24853,6 +24854,7 @@ class MainWindow(QMainWindow):
             "kind": "planet",
             "nickname": payload["nickname"],
             "ids_name_text": payload.get("ids_name_text", ""),
+            "ids_info_text": payload.get("ids_info_text", ""),
             "archetype": payload["archetype"] or "planet",
             "burn_color": payload["burn_color"],
             "radius": payload["radius"],
@@ -25362,11 +25364,17 @@ class MainWindow(QMainWindow):
         ids_name = "261008" if (has_ids_toolchain and spec.get("kind") == "sun") else "0"
         ids_info = "66162" if (has_ids_toolchain and spec.get("kind") == "sun") else "0"
         ids_name_text = str(spec.get("ids_name_text", "") or "").strip()
+        ids_info_text = str(spec.get("ids_info_text", "") or "").strip()
         if ids_name_text and has_ids_toolchain:
             try:
                 ids_name = self._ensure_ids_name_in_user_dll(ids_name, ids_name_text)
             except Exception as exc:
                 QMessageBox.warning(self, tr("msg.save_error"), f"ids_name not written: {exc}")
+        if ids_info_text and has_ids_toolchain:
+            try:
+                ids_info = self._ensure_ids_info_in_user_dll("0", ids_info_text)
+            except Exception as exc:
+                QMessageBox.warning(self, tr("msg.save_error"), f"ids_info not written: {exc}")
 
         entries = [
             ("nickname", spec["nickname"]),
@@ -25427,6 +25435,46 @@ class MainWindow(QMainWindow):
         self.statusBar().showMessage(tr("status.death_zone_created").format(type=created_typ, nickname=spec['nickname']))
         self._pending_create = None
         self._refresh_3d_scene()
+
+    def _planet_ids_info_template_text(self, game_path: str, archetype: str) -> str:
+        arch = str(archetype or "").strip().lower()
+        if not game_path or not arch or "planet" not in arch:
+            return ""
+
+        def _text_from_sections(sections: list[tuple[str, list[tuple[str, str]]]]) -> str:
+            for sec_name, entries in list(sections or []):
+                if str(sec_name).strip().lower() != "object":
+                    continue
+                obj_arch = self._entry_get_value(entries, "archetype").strip().lower()
+                if obj_arch != arch:
+                    continue
+                ids_info = self._safe_int(self._entry_get_value(entries, "ids_info").strip())
+                if ids_info <= 0:
+                    continue
+                xml = str(self._resolve_infocard_xml_by_global_id(ids_info) or "").strip()
+                if xml:
+                    return str(self._display_text_from_ids_value(ids_info) or "").strip()
+            return ""
+
+        current_text = _text_from_sections(self._sections)
+        if current_text:
+            return current_text
+
+        try:
+            for row in self._find_all_systems(game_path):
+                sys_path = str(row.get("path", "") or "").strip()
+                if not sys_path:
+                    continue
+                try:
+                    sections = self._parser.parse(sys_path)
+                except Exception:
+                    continue
+                text = _text_from_sections(sections)
+                if text:
+                    return text
+        except Exception:
+            return ""
+        return ""
 
     # ------------------------------------------------------------------
     #  Tradelane-Generator

--- a/fl_editor/simple_dialog_logic.py
+++ b/fl_editor/simple_dialog_logic.py
@@ -121,6 +121,7 @@ def build_solar_creation_payload(
     *,
     nickname: str,
     ids_name_text: str,
+    ids_info_text: str,
     archetype: str,
     burn_color: str,
     radius: int,
@@ -132,6 +133,7 @@ def build_solar_creation_payload(
     return {
         "nickname": str(nickname or "").strip(),
         "ids_name_text": str(ids_name_text or "").strip(),
+        "ids_info_text": str(ids_info_text or "").strip(),
         "archetype": str(archetype or "").strip(),
         "burn_color": str(burn_color or "").strip(),
         "radius": int(radius),

--- a/tests/test_main_window_smoke.py
+++ b/tests/test_main_window_smoke.py
@@ -7826,6 +7826,52 @@ def test_create_solar_without_ids_toolchain_uses_zero_ids(main_window, monkeypat
     assert str(obj.data.get("ids_info", "")).strip() == "0"
 
 
+def test_create_planet_with_ids_info_text_writes_new_ids_info(main_window, monkeypatch):
+    main_window._filepath = "/tmp/li01.ini"
+    main_window._scale = 1.0
+    main_window._pending_create = {
+        "kind": "planet",
+        "nickname": "li01_planet_01",
+        "ids_name_text": "Planet Name",
+        "ids_info_text": "Planet infocard",
+        "archetype": "planet_desored_1500",
+        "burn_color": "",
+        "radius": 1000,
+        "damage": 100,
+        "atmosphere_range": 1700,
+        "planet_ring": "",
+    }
+    monkeypatch.setattr(main_window, "_has_ids_resource_toolchain", lambda: True)
+    monkeypatch.setattr(main_window, "_ensure_ids_name_in_user_dll", lambda current, text: "123456")
+    monkeypatch.setattr(main_window, "_ensure_ids_info_in_user_dll", lambda current, text: "654321")
+    monkeypatch.setattr(main_window, "_refresh_3d_scene", lambda *args, **kwargs: None)
+
+    main_window._create_solar_at_pos(QPointF(10.0, 20.0))
+
+    obj = main_window._objects[-1]
+    assert str(obj.data.get("ids_name", "")).strip() == "123456"
+    assert str(obj.data.get("ids_info", "")).strip() == "654321"
+
+
+def test_planet_ids_info_template_text_prefers_matching_archetype(main_window, monkeypatch):
+    main_window._sections = [
+        (
+            "Object",
+            [
+                ("nickname", "Li01_02"),
+                ("archetype", "planet_desored_1500"),
+                ("ids_info", "65765"),
+            ],
+        )
+    ]
+    monkeypatch.setattr(main_window, "_resolve_infocard_xml_by_global_id", lambda gid: "<RDL><TEXT><PARA>Pittsburgh</PARA></TEXT></RDL>" if int(gid) == 65765 else "")
+    monkeypatch.setattr(main_window, "_display_text_from_ids_value", lambda gid: "Pittsburgh infocard" if int(gid) == 65765 else "")
+
+    text = main_window._planet_ids_info_template_text("C:/Freelancer", "planet_desored_1500")
+
+    assert text == "Pittsburgh infocard"
+
+
 def test_create_buoy_entries_without_ids_toolchain_uses_zero_ids(main_window, monkeypatch):
     main_window._filepath = "/tmp/li01.ini"
     main_window._scale = 1.0

--- a/tests/test_simple_dialog_logic.py
+++ b/tests/test_simple_dialog_logic.py
@@ -84,6 +84,7 @@ def test_build_solar_creation_payload_normalizes_strings():
     assert build_solar_creation_payload(
         nickname=" sol_a ",
         ids_name_text=" Sun A ",
+        ids_info_text=" Hello World ",
         archetype=" med_star ",
         burn_color="1, 2, 3",
         radius=5000,
@@ -91,7 +92,18 @@ def test_build_solar_creation_payload_normalizes_strings():
         star=" med_white_sun ",
         atmosphere_range=6000,
         planet_ring=" ring.ini ",
-    )["planet_ring"] == "ring.ini"
+    ) == {
+        "nickname": "sol_a",
+        "ids_name_text": "Sun A",
+        "ids_info_text": "Hello World",
+        "archetype": "med_star",
+        "burn_color": "1, 2, 3",
+        "radius": 5000,
+        "damage": 100,
+        "star": "med_white_sun",
+        "atmosphere_range": 6000,
+        "planet_ring": "ring.ini",
+    }
 
 
 def test_build_light_source_payload_normalizes_type():

--- a/tests/test_solar_creation_dialog_logic.py
+++ b/tests/test_solar_creation_dialog_logic.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from PySide6.QtWidgets import QApplication
+
 from fl_editor.dialogs import SolarCreationDialog
 
 
@@ -7,3 +9,25 @@ def test_planet_size_from_archetype_reads_numeric_suffix():
     assert SolarCreationDialog._planet_size_from_archetype("planet_earthgrncld_4000") == 4000
     assert SolarCreationDialog._planet_size_from_archetype("planet_moon_250.5") == 250
     assert SolarCreationDialog._planet_size_from_archetype("planet_unknown") is None
+
+
+def test_solar_creation_dialog_updates_ids_info_text_from_provider(qapp):
+    dialog = SolarCreationDialog(
+        None,
+        "Create Planet",
+        ["planet_desored_1500", "planet_earthgrncld_4000"],
+        default_radius=1500,
+        default_damage=200000,
+        enable_planet_ring=True,
+        ids_info_text_provider=lambda archetype: {
+            "planet_desored_1500": "Pittsburgh template",
+            "planet_earthgrncld_4000": "Manhattan template",
+        }.get(str(archetype), ""),
+    )
+    try:
+        assert dialog.ids_info_edit.toPlainText().strip() == "Pittsburgh template"
+        dialog.arch_cb.setCurrentText("planet_earthgrncld_4000")
+        QApplication.processEvents()
+        assert dialog.ids_info_edit.toPlainText().strip() == "Manhattan template"
+    finally:
+        dialog.close()


### PR DESCRIPTION
## Summary
- allow creating and editing planet ids_info text directly in the solar creation dialog
- prefill planet infocard text from an existing planet with the same archetype when available
- write the edited text as a new ids_info entry so template infocards are not modified in place

## Testing
- `.\.venv\Scripts\python.exe -m pytest tests\test_simple_dialog_logic.py tests\test_solar_creation_dialog_logic.py -q`
- `.\.venv\Scripts\python.exe -m pytest tests\test_main_window_smoke.py -k "create_solar_without_ids_toolchain_uses_zero_ids or create_planet_with_ids_info_text_writes_new_ids_info or planet_ids_info_template_text_prefers_matching_archetype" -q`

Closes #27