### PR TITLE
Add ids_info text editing to 2D object editor

### DIFF
--- a/fl_editor/main_window.py
+++ b/fl_editor/main_window.py
@@ -23159,8 +23159,15 @@ class MainWindow(QMainWindow):
         nick_edit = QLineEdit(obj.data.get("nickname", obj.nickname))
         ids_name_current = str(obj.data.get("ids_name", "") or "").strip()
         ids_name_display = self._display_name_from_ids_name(ids_name_current) if ids_name_current else ""
+        ids_info_current = str(obj.data.get("ids_info", "") or "").strip()
+        ids_info_display = self._display_text_from_ids_value(ids_info_current) if ids_info_current else ""
         ids_name_text_edit = QLineEdit(ids_name_display)
         ids_name_text_edit.setPlaceholderText("Ingame Name (ids_name)")
+        ids_info_text_edit = QTextEdit()
+        ids_info_text_edit.setMinimumHeight(110)
+        ids_info_text_edit.setLineWrapMode(QTextEdit.WidgetWidth)
+        ids_info_text_edit.setPlaceholderText("Info text / Infocard text (ids_info)")
+        ids_info_text_edit.setPlainText(ids_info_display)
         arch_cb = QComboBox()
         arch_cb.setEditable(True)
         arch_vals = [self.arch_cb.itemText(i) for i in range(self.arch_cb.count()) if self.arch_cb.itemText(i)]
@@ -23205,6 +23212,7 @@ class MainWindow(QMainWindow):
 
         fl.addRow("Nickname", nick_edit)
         fl.addRow("Ingame Name", ids_name_text_edit)
+        fl.addRow("ids_info Text", ids_info_text_edit)
         fl.addRow("Archetype", arch_cb)
         fl.addRow("Loadout", loadout_cb)
         fl.addRow("Reputation", faction_cb)
@@ -23231,16 +23239,22 @@ class MainWindow(QMainWindow):
             "pos": f"{pos_x.value():.2f}, {pos_y.value():.2f}, {pos_z.value():.2f}",
             "rotate": f"{rot_x.value():.2f}, {rot_y.value():.2f}, {rot_z.value():.2f}",
         }
-        new_ids_name = ids_name_current
-        ids_name_new_text = ids_name_text_edit.text().strip()
-        if ids_name_new_text and ids_name_new_text != ids_name_display:
-            try:
-                new_ids_name = self._ensure_ids_name_in_user_dll(ids_name_current, ids_name_new_text)
-            except Exception as exc:
-                QMessageBox.warning(self, tr("msg.save_error"), f"ids_name not written: {exc}")
-                return
+        try:
+            new_ids_name, new_ids_info = self._apply_scene_object_text_id_edits(
+                current_ids_name=ids_name_current,
+                ids_name_display=ids_name_display,
+                ids_name_new_text=ids_name_text_edit.text(),
+                current_ids_info=ids_info_current,
+                ids_info_display=ids_info_display,
+                ids_info_new_text=ids_info_text_edit.toPlainText(),
+            )
+        except Exception as exc:
+            QMessageBox.warning(self, tr("msg.save_error"), f"ids text not written: {exc}")
+            return
         if new_ids_name:
             new_map["ids_name"] = new_ids_name
+        if new_ids_info:
+            new_map["ids_info"] = new_ids_info
 
         entries = list(obj.data.get("_entries", []))
         changed_keys: set[str] = set()
@@ -23911,6 +23925,29 @@ class MainWindow(QMainWindow):
     @staticmethod
     def _safe_int(raw: str | int | None) -> int:
         return safe_int(raw)
+
+    def _apply_scene_object_text_id_edits(
+        self,
+        *,
+        current_ids_name: str | int | None,
+        ids_name_display: str,
+        ids_name_new_text: str,
+        current_ids_info: str | int | None,
+        ids_info_display: str,
+        ids_info_new_text: str,
+    ) -> tuple[str, str]:
+        new_ids_name = str(current_ids_name or "").strip()
+        new_ids_info = str(current_ids_info or "").strip()
+
+        ids_name_new_text = str(ids_name_new_text or "").strip()
+        if ids_name_new_text and ids_name_new_text != str(ids_name_display or "").strip():
+            new_ids_name = str(self._ensure_ids_name_in_user_dll(current_ids_name, ids_name_new_text) or "").strip()
+
+        ids_info_new_text = str(ids_info_new_text or "").strip()
+        if ids_info_new_text and ids_info_new_text != str(ids_info_display or "").strip():
+            new_ids_info = str(self._ensure_ids_info_in_user_dll(current_ids_info, ids_info_new_text) or "").strip()
+
+        return new_ids_name, new_ids_info
 
     def _edit_infocard_for_scene_object(self, obj: SolarObject):
         if not isinstance(obj, SolarObject) or hasattr(obj, "sys_path"):

--- a/tests/test_main_window_smoke.py
+++ b/tests/test_main_window_smoke.py
@@ -7872,6 +7872,65 @@ def test_planet_ids_info_template_text_prefers_matching_archetype(main_window, m
     assert text == "Pittsburgh infocard"
 
 
+def test_apply_scene_object_text_id_edits_writes_changed_ids_name_and_ids_info(main_window, monkeypatch):
+    calls: list[tuple[str, str, str]] = []
+
+    def _write_name(current, text):
+        calls.append(("name", str(current), str(text)))
+        return "123456"
+
+    def _write_info(current, text):
+        calls.append(("info", str(current), str(text)))
+        return "654321"
+
+    monkeypatch.setattr(main_window, "_ensure_ids_name_in_user_dll", _write_name)
+    monkeypatch.setattr(main_window, "_ensure_ids_info_in_user_dll", _write_info)
+
+    new_ids_name, new_ids_info = main_window._apply_scene_object_text_id_edits(
+        current_ids_name="111",
+        ids_name_display="Planet Manhattan",
+        ids_name_new_text="Planet Manhattan Prime",
+        current_ids_info="222",
+        ids_info_display="Old infocard",
+        ids_info_new_text="New infocard",
+    )
+
+    assert new_ids_name == "123456"
+    assert new_ids_info == "654321"
+    assert calls == [
+        ("name", "111", "Planet Manhattan Prime"),
+        ("info", "222", "New infocard"),
+    ]
+
+
+def test_apply_scene_object_text_id_edits_skips_unchanged_ids_info(main_window, monkeypatch):
+    calls: list[tuple[str, str, str]] = []
+
+    monkeypatch.setattr(
+        main_window,
+        "_ensure_ids_name_in_user_dll",
+        lambda current, text: calls.append(("name", str(current), str(text))) or "123456",
+    )
+    monkeypatch.setattr(
+        main_window,
+        "_ensure_ids_info_in_user_dll",
+        lambda current, text: calls.append(("info", str(current), str(text))) or "654321",
+    )
+
+    new_ids_name, new_ids_info = main_window._apply_scene_object_text_id_edits(
+        current_ids_name="111",
+        ids_name_display="Planet Manhattan",
+        ids_name_new_text="Planet Manhattan",
+        current_ids_info="222",
+        ids_info_display="Existing infocard",
+        ids_info_new_text="Existing infocard",
+    )
+
+    assert new_ids_name == "111"
+    assert new_ids_info == "222"
+    assert calls == []
+
+
 def test_create_buoy_entries_without_ids_toolchain_uses_zero_ids(main_window, monkeypatch):
     main_window._filepath = "/tmp/li01.ini"
     main_window._scale = 1.0


### PR DESCRIPTION
## Summary
- add editable ids_info text support to the 2D system object editor
- write changed ids_info text back through the existing user DLL flow
- cover changed and unchanged ids_name/ids_info edit paths with smoke tests

## Testing
- `.\.venv\Scripts\python.exe -m pytest tests\test_main_window_smoke.py -k "apply_scene_object_text_id_edits or create_planet_with_ids_info_text_writes_new_ids_info or planet_ids_info_template_text_prefers_matching_archetype" -q`

Closes #35