### PR TITLE
Prefer bundled tab labels for legacy user translations

### DIFF
--- a/fl_editor/i18n.py
+++ b/fl_editor/i18n.py
@@ -17,8 +17,6 @@ Usage::
 from __future__ import annotations
 
 import json
-import os
-import shutil
 from pathlib import Path
 from typing import Dict
 
@@ -34,21 +32,43 @@ _USER_FILE = _USER_DIR / "translations.json"
 # ---------------------------------------------------------------------------
 _translations: Dict[str, Dict[str, str]] = {}
 _current_lang: str = "en"
+_BUNDLED_PRIORITY_KEYS = {
+    "mod_manager.title",
+    "mod_settings.title",
+}
+_BUNDLED_PRIORITY_PREFIXES = (
+    "action.",
+    "app.title",
+)
+
+
+def _is_bundled_priority_key(key: str) -> bool:
+    normalized = str(key or "").strip()
+    return normalized in _BUNDLED_PRIORITY_KEYS or normalized.startswith(_BUNDLED_PRIORITY_PREFIXES)
+
+
+def _looks_like_legacy_full_copy(base_lang: Dict[str, str], user_lang: Dict[str, str]) -> bool:
+    if not isinstance(base_lang, dict) or not isinstance(user_lang, dict):
+        return False
+    base_count = len(base_lang)
+    user_count = len(user_lang)
+    if base_count < 20:
+        return False
+    return user_count >= max(20, int(base_count * 0.7))
 
 
 def _load_translations() -> None:
     """(Re)load translations from disk.
 
-    The user file takes priority.  If it doesn't exist yet the bundled copy
-    is placed there so users can customise it.
+    The user file takes priority. Legacy installs may still carry a full copy
+    of an old bundled translation file in the user location; for a small set
+    of core navigation captions we prefer the bundled values in that case so
+    renamed tabs stay in sync after updates.
     """
     global _translations
 
-    # Ensure user file exists
     if not _USER_FILE.exists():
         _USER_DIR.mkdir(parents=True, exist_ok=True)
-        if _BUNDLED_FILE.exists():
-            shutil.copy2(_BUNDLED_FILE, _USER_FILE)
 
     bundled_data: Dict[str, Dict[str, str]] = {}
     user_data: Dict[str, Dict[str, str]] = {}
@@ -71,7 +91,13 @@ def _load_translations() -> None:
     for lang in set(bundled_data.keys()) | set(user_data.keys()):
         base_lang = bundled_data.get(lang, {})
         user_lang = user_data.get(lang, {})
-        merged[lang] = {**base_lang, **user_lang}
+        merged_lang = dict(base_lang)
+        legacy_full_copy = _looks_like_legacy_full_copy(base_lang, user_lang)
+        for key, value in user_lang.items():
+            if legacy_full_copy and key in base_lang and _is_bundled_priority_key(key):
+                continue
+            merged_lang[key] = value
+        merged[lang] = merged_lang
     _translations = merged
 
 

--- a/tests/test_i18n.py
+++ b/tests/test_i18n.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import importlib
+import json
+from pathlib import Path
+
+
+def _write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, ensure_ascii=False), encoding="utf-8")
+
+
+def test_i18n_legacy_full_copy_keeps_bundled_tab_names(monkeypatch, tmp_path: Path):
+    bundled = tmp_path / "bundled.json"
+    user = tmp_path / "user.json"
+
+    bundled_payload = {
+        "en": {
+            "action.ini_editor": "File Explorer",
+            "action.name_editor": "Name & Info Editor",
+            **{f"misc.key_{idx}": f"Bundled {idx}" for idx in range(24)},
+        }
+    }
+    user_payload = {
+        "en": {
+            "action.ini_editor": "INI Editor",
+            "action.name_editor": "Name Editor",
+            **{f"misc.key_{idx}": f"Old {idx}" for idx in range(24)},
+            "misc.key_3": "Custom legacy text",
+        }
+    }
+    _write_json(bundled, bundled_payload)
+    _write_json(user, user_payload)
+
+    import fl_editor.i18n as i18n_module
+
+    monkeypatch.setattr(i18n_module, "_BUNDLED_FILE", bundled)
+    monkeypatch.setattr(i18n_module, "_USER_FILE", user)
+    monkeypatch.setattr(i18n_module, "_USER_DIR", user.parent)
+
+    i18n_module = importlib.reload(i18n_module)
+    monkeypatch.setattr(i18n_module, "_BUNDLED_FILE", bundled)
+    monkeypatch.setattr(i18n_module, "_USER_FILE", user)
+    monkeypatch.setattr(i18n_module, "_USER_DIR", user.parent)
+    i18n_module.reload_translations()
+    i18n_module.set_language("en")
+
+    assert i18n_module.tr("action.ini_editor") == "File Explorer"
+    assert i18n_module.tr("action.name_editor") == "Name & Info Editor"
+    assert i18n_module.tr("misc.key_3") == "Custom legacy text"
+
+
+def test_i18n_sparse_user_override_can_still_override_tab_names(monkeypatch, tmp_path: Path):
+    bundled = tmp_path / "bundled.json"
+    user = tmp_path / "user.json"
+
+    _write_json(
+        bundled,
+        {
+            "en": {
+                "action.ini_editor": "File Explorer",
+                **{f"misc.key_{idx}": f"Bundled {idx}" for idx in range(24)},
+            }
+        },
+    )
+    _write_json(user, {"en": {"action.ini_editor": "Custom Explorer"}})
+
+    import fl_editor.i18n as i18n_module
+
+    monkeypatch.setattr(i18n_module, "_BUNDLED_FILE", bundled)
+    monkeypatch.setattr(i18n_module, "_USER_FILE", user)
+    monkeypatch.setattr(i18n_module, "_USER_DIR", user.parent)
+
+    i18n_module = importlib.reload(i18n_module)
+    monkeypatch.setattr(i18n_module, "_BUNDLED_FILE", bundled)
+    monkeypatch.setattr(i18n_module, "_USER_FILE", user)
+    monkeypatch.setattr(i18n_module, "_USER_DIR", user.parent)
+    i18n_module.reload_translations()
+    i18n_module.set_language("en")
+
+    assert i18n_module.tr("action.ini_editor") == "Custom Explorer"
+
+
+def test_i18n_large_legacy_partial_copy_still_prefers_bundled_tab_names(monkeypatch, tmp_path: Path):
+    bundled = tmp_path / "bundled.json"
+    user = tmp_path / "user.json"
+
+    bundled_keys = {
+        "action.ini_editor": "File Explorer",
+        "action.name_editor": "Name & Info Editor",
+        **{f"misc.key_{idx}": f"Bundled {idx}" for idx in range(100)},
+    }
+    user_keys = {f"misc.key_{idx}": f"Legacy {idx}" for idx in range(74)}
+    user_keys["action.ini_editor"] = "INI Editor"
+
+    _write_json(bundled, {"en": bundled_keys})
+    _write_json(user, {"en": user_keys})
+
+    import fl_editor.i18n as i18n_module
+
+    monkeypatch.setattr(i18n_module, "_BUNDLED_FILE", bundled)
+    monkeypatch.setattr(i18n_module, "_USER_FILE", user)
+    monkeypatch.setattr(i18n_module, "_USER_DIR", user.parent)
+
+    i18n_module = importlib.reload(i18n_module)
+    monkeypatch.setattr(i18n_module, "_BUNDLED_FILE", bundled)
+    monkeypatch.setattr(i18n_module, "_USER_FILE", user)
+    monkeypatch.setattr(i18n_module, "_USER_DIR", user.parent)
+    i18n_module.reload_translations()
+    i18n_module.set_language("en")
+
+    assert i18n_module.tr("action.ini_editor") == "File Explorer"
+    assert i18n_module.tr("misc.key_10") == "Legacy 10"


### PR DESCRIPTION
## Summary
- detect legacy user translation files that still mirror an old bundled translation set
- prefer current bundled navigation and tab captions for those legacy translation files
- keep small targeted user translation overrides working as before

## Testing
- `.\.venv\Scripts\python.exe -m pytest tests\test_i18n.py -q`

Closes #36