### PR TITLE
Fix #40 preserve per-tab system zoom state

### DIFF
--- a/fl_editor/system_document_runtime.py
+++ b/fl_editor/system_document_runtime.py
@@ -1,0 +1,364 @@
+"""Runtime helpers for applying and loading system editor documents."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+from PySide6.QtCore import QObject, QPointF, QRectF, QTimer
+from PySide6.QtGui import QTransform
+from PySide6.QtWidgets import QGraphicsItem
+
+from .async_ui_runtime import start_async_view_load
+from .i18n import tr
+from .models import SolarObject, ZoneItem
+from .path_utils import is_offmap_helper_object_data
+
+
+def _reset_change_tracking(window: Any, doc: object | None) -> None:
+    if doc is not None and hasattr(doc, "change_snapshots"):
+        window._change_snapshots = deepcopy(getattr(doc, "change_snapshots", []))
+        window._last_snapshot_fp = str(getattr(doc, "last_snapshot_fp", "") or "")
+        window._history_restore_in_progress = bool(getattr(doc, "history_restore_in_progress", False))
+        window._undo_actions = deepcopy(getattr(doc, "undo_actions", []))
+        window._change_log_entries = list(getattr(doc, "change_log_entries", []))
+        return
+    window._change_snapshots = []
+    window._last_snapshot_fp = ""
+    window._history_restore_in_progress = False
+    window._undo_actions = []
+    window._change_log_entries = []
+
+
+def _system_boundary_radius(raw_objects: list[dict[str, Any]]) -> float:
+    rmax = 0.0
+    for data in raw_objects:
+        pp = [float(c.strip()) for c in str(data.get("pos", "0,0,0")).split(",")]
+        fx = pp[0] if len(pp) > 0 else 0.0
+        fz = pp[2] if len(pp) > 2 else (pp[1] if len(pp) > 1 else 0.0)
+        dist = (fx * fx + fz * fz) ** 0.5
+        size = 0.0
+        if "size" in data:
+            try:
+                size = float(str(data["size"]).split(",")[0])
+            except Exception:
+                pass
+        rmax = max(rmax, dist + size)
+    return rmax
+
+
+def _effective_system_boundary_radius(
+    window: Any,
+    path: str,
+    sections: list[tuple[str, list[tuple[str, str]]]],
+    raw_objects: list[dict[str, Any]],
+) -> float:
+    resolver = getattr(window, "_resolve_system_boundary_radius_world", None)
+    if callable(resolver):
+        try:
+            resolved = resolver(path, sections=sections, raw_objects=raw_objects)
+        except TypeError:
+            resolved = resolver(path, sections, raw_objects)
+        try:
+            return float(resolved)
+        except Exception:
+            pass
+    return _system_boundary_radius(raw_objects)
+
+
+def _restore_view_transform_and_center(window: Any, restore: object | None) -> bool:
+    transform = None
+    center_scene = None
+    if isinstance(restore, dict):
+        candidate_transform = restore.get("transform")
+        if isinstance(candidate_transform, QTransform):
+            transform = candidate_transform
+        candidate_center = restore.get("center_scene")
+        if isinstance(candidate_center, QPointF):
+            center_scene = candidate_center
+    elif isinstance(restore, QTransform):
+        transform = restore
+    if transform is None and center_scene is None:
+        return False
+    if transform is not None:
+        window.view.setTransform(transform)
+    if center_scene is not None and hasattr(window.view, "centerOn"):
+        try:
+            window.view.centerOn(center_scene)
+        except Exception:
+            pass
+    window._sync_zoom_slider_from_view(window.view.current_zoom_factor())
+    return True
+
+
+def _build_workspace_state(window: Any) -> Any:
+    factory = getattr(window, "_workspace_layout_state_factory", None)
+    kwargs = {
+        "left_widget": getattr(window, "left_ini_panel", None),
+        "left_sidebar_visible": True,
+        "right_panel_visible": True,
+        "legend_visible": True,
+        "zoom_controls_visible": True,
+        "view3d_toggle_visible": True,
+        "view3d_toggle_enabled": True,
+        "view3d_toggle_checked": bool(window.view3d_switch.isChecked()),
+        "sidebar_3d_enabled": True,
+    }
+    if callable(factory):
+        return factory(**kwargs)
+    return SimpleNamespace(**kwargs)
+
+
+def _rebuild_system_scene(window: Any, raw_zones: list[dict[str, Any]], raw_objects: list[dict[str, Any]]) -> None:
+    window.view._scene.clear()
+    window.view._scene.setSceneRect(0, 0, 0, 0)
+    window._apply_scene_wallpaper()
+    window._objects, window._zones = [], []
+    window._selected = None
+    window._clear_selection_ui()
+    window._hide_zone_extra_editors()
+
+    for zone_data in raw_zones:
+        try:
+            zone = ZoneItem(zone_data, window._scale)
+            if hasattr(zone, "set_label_visibility"):
+                zone.set_label_visibility(window._viewer_text_visible)
+            window.view._scene.addItem(zone)
+            window._zones.append(zone)
+        except Exception:
+            pass
+
+    movable = window.move_cb.isChecked()
+    SolarObject.set_top_view_icon_auto_refresh_enabled(False)
+    try:
+        for object_data in raw_objects:
+            try:
+                obj = SolarObject(object_data, window._scale)
+                if getattr(obj, "label", None):
+                    obj.label.setPlainText(window._object_display_label(obj))
+                if hasattr(obj, "set_label_visibility"):
+                    obj.set_label_visibility(window._viewer_text_visible)
+                obj.setFlag(QGraphicsItem.ItemIsMovable, movable)
+                window.view._scene.addItem(obj)
+                window._objects.append(obj)
+            except Exception:
+                pass
+    finally:
+        SolarObject.set_top_view_icon_auto_refresh_enabled(True)
+
+
+def _apply_system_document_data(
+    window: Any,
+    path: str,
+    sections: list[tuple[str, list[tuple[str, str]]]],
+    raw_zones: list[dict[str, Any]],
+    raw_objects: list[dict[str, Any]],
+    boundary_radius: float,
+    restore: QTransform | None = None,
+    dirty: bool = False,
+    doc: object | None = None,
+) -> None:
+    window._filepath = path
+    window._sections = deepcopy(sections)
+    _reset_change_tracking(window, doc)
+    if doc is not None and hasattr(doc, "pending_zone"):
+        window._restore_system_tab_pending_state(doc)
+    window._reload_dll_name_cache()
+
+    grid_half_resolver = getattr(window, "_system_reference_half_extent_world", None)
+    grid_half = float(grid_half_resolver(float(boundary_radius or 0.0))) if callable(grid_half_resolver) else 10000.0
+    extent_world = max(float(boundary_radius or 0.0), grid_half, 10000.0)
+    window._scale = 500.0 / extent_world
+    window.view.set_world_scale(window._scale)
+    window.view.set_zoom_out_limit_to_scene(True)
+    zoom_reference_rect = QRectF()
+    reference_rect_resolver = getattr(window, "_system_zoom_reference_rect", None)
+    if callable(reference_rect_resolver):
+        try:
+            zoom_reference_rect = QRectF(reference_rect_resolver(float(boundary_radius or 0.0)))
+        except Exception:
+            zoom_reference_rect = QRectF()
+    if hasattr(window.view, "set_zoom_out_reference_rect"):
+        window.view.set_zoom_out_reference_rect(zoom_reference_rect if not zoom_reference_rect.isNull() else None)
+    if hasattr(window.view, "set_zoom_in_limit_multiplier"):
+        window.view.set_zoom_in_limit_multiplier(40.0)
+    window.view.set_unbounded_pan(False)
+    window.view.set_left_drag_pan_enabled(False)
+    window._set_system_zoom_controls_visible(True)
+    window._clear_move_delta_indicator()
+
+    _rebuild_system_scene(window, raw_zones, raw_objects)
+    window._draw_system_reference_overlay(float(boundary_radius or 0.0))
+    window._apply_group_visibility()
+    if window._avoid_label_overlap:
+        window._reflow_2d_labels()
+    else:
+        window._reset_2d_label_positions()
+
+    sys_nick = window._system_nickname_for_path(path)
+    name = window._system_display_name(sys_nick)
+    if hasattr(window, "_sys_header_lbl"):
+        window._sys_header_lbl.setText(window._format_system_header_text(sys_nick))
+    window.info_lbl.setText(
+        tr("info.system").format(filename=Path(path).name, obj_count=len(window._objects), zone_count=len(window._zones))
+    )
+    window._rebuild_object_combo()
+    window._update_base_child_interactivity()
+    window.setWindowTitle(window._title_with_version(tr("app.title_system").format(name=name)))
+    window.statusBar().showMessage(
+        tr("status.system_loaded").format(name=name, obj_count=len(window._objects), zone_count=len(window._zones))
+    )
+    window._apply_workspace_layout(_build_workspace_state(window))
+    if hasattr(window, "_status_grp"):
+        window._status_grp.setVisible(False)
+    window._set_global_nav_active("universe")
+    window._new_system_action.setVisible(False)
+    window._uni_save_action.setVisible(False)
+    window._uni_undo_action.setVisible(False)
+    window._uni_delete_action.setVisible(False)
+    window.uni_delete_btn.setEnabled(False)
+    window._ids_scan_action.setVisible(False)
+    window._ids_import_action.setVisible(False)
+    window._set_dirty(False)
+    if not _restore_view_transform_and_center(window, restore):
+        window._fit()
+    window._refresh_viewer_move_border()
+    window._populate_system_options()
+    if callable(getattr(window, "_apply_system_name_mode_to_ui", None)):
+        window._apply_system_name_mode_to_ui()
+    if hasattr(window, "_sys_header_lbl"):
+        window._sys_header_lbl.setText(window._format_system_header_text(sys_nick))
+    window.setWindowTitle(window._title_with_version(tr("app.title_system").format(name=window._system_display_name(sys_nick))))
+    window._build_standard_menu_bar()
+    window._refresh_system_fields()
+    if hasattr(window, "_change_undo_btn"):
+        window._change_undo_btn.setEnabled(bool(window._change_snapshots) or bool(window._undo_actions))
+    if hasattr(window, "change_log_view"):
+        try:
+            window.change_log_view.setPlainText("\n".join(window._collect_change_log_lines()))
+        except Exception:
+            pass
+    if dirty:
+        window._set_dirty(True)
+    should_refresh_3d = bool(
+        callable(getattr(window, "_refresh_3d_scene", None))
+        and hasattr(window, "view3d_switch")
+        and bool(window.view3d_switch.isChecked())
+    )
+    should_populate_quick_options = bool(
+        callable(getattr(window, "_primary_game_path", None))
+        and callable(getattr(window, "_populate_quick_editor_options", None))
+    )
+
+    if not (should_refresh_3d or should_populate_quick_options):
+        queue_top_view_icons = getattr(window, "_queue_top_view_icon_refresh", None)
+        if callable(queue_top_view_icons):
+            queue_top_view_icons(getattr(window, "_objects", []) or [])
+        return
+
+    if callable(getattr(window, "_set_loading_visible", None)):
+        window._set_loading_visible(True, tr("status.preparing_system_view"))
+
+    def _run_deferred_post_load() -> None:
+        try:
+            queue_top_view_icons = getattr(window, "_queue_top_view_icon_refresh", None)
+            if callable(queue_top_view_icons):
+                queue_top_view_icons(getattr(window, "_objects", []) or [])
+            if should_refresh_3d:
+                # Preserve the restored per-tab camera so deferred scene rebuilds
+                # do not snap the user back to the default system framing.
+                window._refresh_3d_scene(preserve_camera=True)
+            if should_populate_quick_options:
+                window._populate_quick_editor_options(window._primary_game_path())
+        finally:
+            if callable(getattr(window, "_set_loading_visible", None)):
+                window._set_loading_visible(False)
+
+    QTimer.singleShot(0, _run_deferred_post_load)
+
+
+def collect_system_document_payload(window: Any, path: str, restore: QTransform | None = None) -> dict[str, Any]:
+    sections = window._parser.parse(path)
+    raw_objects = [obj for obj in window._parser.get_objects(sections) if not is_offmap_helper_object_data(obj)]
+    raw_zones = window._parser.get_zones(sections)
+    return {
+        "path": str(path),
+        "sections": sections,
+        "raw_objects": raw_objects,
+        "raw_zones": raw_zones,
+        "boundary_radius": _effective_system_boundary_radius(window, str(path), sections, raw_objects),
+        "restore": restore,
+    }
+
+
+def apply_system_document_payload(window: Any, payload: dict[str, Any], *, dirty: bool = False, doc: object | None = None) -> None:
+    _apply_system_document_data(
+        window,
+        str(payload.get("path", "") or ""),
+        list(payload.get("sections", []) or []),
+        list(payload.get("raw_zones", []) or []),
+        list(payload.get("raw_objects", []) or []),
+        float(payload.get("boundary_radius", 0.0) or 0.0),
+        restore=payload.get("restore"),
+        dirty=dirty,
+        doc=doc,
+    )
+
+
+def apply_system_document(
+    window: Any,
+    path: str,
+    sections: list[tuple[str, list[tuple[str, str]]]],
+    restore: QTransform | None = None,
+    dirty: bool = False,
+    doc: object | None = None,
+) -> None:
+    raw_objects = [obj for obj in window._parser.get_objects(sections) if not is_offmap_helper_object_data(obj)]
+    raw_zones = window._parser.get_zones(sections)
+    _apply_system_document_data(
+        window,
+        path,
+        sections,
+        raw_zones,
+        raw_objects,
+        _effective_system_boundary_radius(window, str(path), sections, raw_objects),
+        restore=restore,
+        dirty=dirty,
+        doc=doc,
+    )
+
+
+def load_system(window: Any, path: str, restore: QTransform | None = None) -> None:
+    if window._flight_lock_active:
+        window._set_flight_mode(False)
+    window._pending_conn = None
+    window._pending_create = None
+    window._pending_light_source = None
+    window._pending_new_object = False
+    window._pending_tradelane = None
+    window._pending_tl_reposition = None
+    window._set_placement_mode(False)
+    if not isinstance(window, QObject):
+        if callable(getattr(window, "_set_loading_visible", None)):
+            window._set_loading_visible(True, tr("status.loading_system"))
+        try:
+            sections = window._parser.parse(path)
+            if callable(getattr(window, "_apply_system_document", None)):
+                window._apply_system_document(path, sections, restore=restore, dirty=False)
+            else:
+                apply_system_document(window, path, sections, restore=restore, dirty=False)
+        finally:
+            if callable(getattr(window, "_set_loading_visible", None)):
+                window._set_loading_visible(False)
+        return
+
+    start_async_view_load(
+        window,
+        key="system-load",
+        worker=lambda: collect_system_document_payload(window, path, restore=restore),
+        apply_result=lambda payload: apply_system_document_payload(window, payload, dirty=False),
+        loading_message=tr("status.loading_system"),
+        error_title=tr("msg.load_error"),
+    )

--- a/fl_editor/system_tab_document_runtime.py
+++ b/fl_editor/system_tab_document_runtime.py
@@ -1,0 +1,302 @@
+"""Runtime helpers for system-tab document and editor state."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from types import SimpleNamespace
+from typing import Any
+
+from PySide6.QtGui import QTransform
+
+from .system_tabs import apply_dirty_system_tab_title
+from .models import ZoneItem
+from .system_editor_persistence import build_saved_system_sections
+
+
+def _left_panel_mode(window: Any) -> str:
+    if not hasattr(window, "left_stack"):
+        return "ini"
+    current = window.left_stack.currentWidget()
+    mapping = (
+        ("browser", getattr(window, "browser", None)),
+        ("ini", getattr(window, "left_ini_panel", None)),
+        ("universe", getattr(window, "left_uni_panel", None)),
+        ("trade", getattr(window, "left_trade_panel", None)),
+        ("name", getattr(window, "left_name_panel", None)),
+    )
+    for key, widget in mapping:
+        if widget is not None and current is widget:
+            return key
+    return "ini"
+
+
+def _left_widget_for_mode(window: Any, mode: str) -> object | None:
+    mapping = {
+        "browser": getattr(window, "browser", None),
+        "ini": getattr(window, "left_ini_panel", None),
+        "universe": getattr(window, "left_uni_panel", None),
+        "trade": getattr(window, "left_trade_panel", None),
+        "name": getattr(window, "left_name_panel", None),
+    }
+    return mapping.get(str(mode or "").strip().lower(), getattr(window, "left_ini_panel", None))
+
+
+def capture_system_tab_state(window: Any, key: str | None = None) -> None:
+    spec = window._center_system_tab_spec(key)
+    if spec is None or not window._filepath:
+        return
+    doc = spec.get("document")
+    if doc is None or not hasattr(doc, "path"):
+        factory = getattr(window, "_system_document_factory", None)
+        if factory is None:
+            return
+        doc = factory(path=str(window._filepath))
+        spec["document"] = doc
+    try:
+        doc.view_transform = QTransform(window.view.transform())
+    except Exception:
+        pass
+    try:
+        doc.use_3d = bool(window.view3d_switch.isChecked())
+    except Exception:
+        doc.use_3d = False
+    try:
+        if hasattr(window.view3d, "get_camera_state"):
+            cam_state = window.view3d.get_camera_state()
+            if isinstance(cam_state, dict):
+                doc.camera_state = dict(cam_state)
+    except Exception:
+        pass
+    if window._selected is None:
+        doc.selected_kind = ""
+        doc.selected_nickname = ""
+    else:
+        doc.selected_kind = "zone" if isinstance(window._selected, ZoneItem) else "object"
+        doc.selected_nickname = str(getattr(window._selected, "nickname", "") or "").strip()
+
+
+def _restore_system_tab_pending_state(window: Any, doc: object | None) -> None:
+    is_doc = doc is not None and hasattr(doc, "pending_zone")
+    window._pending_zone = deepcopy(doc.pending_zone) if is_doc else None
+    window._pending_simple_zone = deepcopy(doc.pending_simple_zone) if is_doc else None
+    window._pending_exclusion_zone = deepcopy(doc.pending_exclusion_zone) if is_doc else None
+    window._pending_light_source = deepcopy(doc.pending_light_source) if is_doc else None
+    window._pending_template_object = deepcopy(doc.pending_template_object) if is_doc else None
+    window._pending_buoy = deepcopy(doc.pending_buoy) if is_doc else None
+    window._pending_create = deepcopy(doc.pending_create) if is_doc else None
+    window._pending_new_object = bool(doc.pending_new_object) if is_doc else False
+    window._pending_conn = deepcopy(doc.pending_conn) if is_doc else None
+    window._pending_snapshots = deepcopy(doc.pending_snapshots) if is_doc else []
+    window._pending_new_system = deepcopy(doc.pending_new_system) if is_doc else None
+    window._pending_tradelane = deepcopy(doc.pending_tradelane) if is_doc else None
+    window._pending_tl_reposition = deepcopy(doc.pending_tl_reposition) if is_doc else None
+    window._pending_base = deepcopy(doc.pending_base) if is_doc else None
+    window._pending_dock_ring = deepcopy(doc.pending_dock_ring) if is_doc else None
+    window._pending_ring_attach = deepcopy(doc.pending_ring_attach) if is_doc else None
+    window._clear_pending_visual_helpers()
+    if hasattr(window, "save_conn_btn"):
+        window.save_conn_btn.setVisible(bool(window._pending_snapshots))
+    if hasattr(window, "create_conn_btn"):
+        window.create_conn_btn.setEnabled(not bool(window._pending_snapshots))
+    if window._has_pending_placement():
+        mode_text = str(getattr(doc, "pending_mode_text", "") or "").strip() if is_doc else ""
+        window._set_placement_mode(True, "")
+        if mode_text:
+            window.mode_lbl.setText(mode_text)
+    else:
+        window._set_placement_mode(False)
+
+
+def restore_system_tab_editor_state(window: Any, doc: object | None) -> None:
+    if doc is None or not hasattr(doc, "editor_text"):
+        return
+    if hasattr(window, "left_stack") and hasattr(window, "left_ini_panel"):
+        window.left_stack.setCurrentWidget(window.left_ini_panel)
+    if hasattr(window, "editor"):
+        window.editor.setPlainText(str(doc.editor_text or ""))
+        window.editor.setVisible(bool(doc.editor_visible))
+        try:
+            tc = window.editor.textCursor()
+            tc.setPosition(max(0, min(int(doc.editor_cursor_pos), len(window.editor.toPlainText()))))
+            window.editor.setTextCursor(tc)
+        except Exception:
+            pass
+    if hasattr(window, "apply_btn"):
+        window.apply_btn.setVisible(bool(doc.apply_visible))
+    if hasattr(window, "zone_link_editor"):
+        window.zone_link_editor.setPlainText(str(doc.zone_link_text or ""))
+        window.zone_link_editor.setVisible(bool(doc.zone_link_visible))
+    if hasattr(window, "zone_link_lbl"):
+        window.zone_link_lbl.setVisible(bool(doc.zone_link_visible))
+    if hasattr(window, "zone_file_editor"):
+        window.zone_file_editor.setPlainText(str(doc.zone_file_text or ""))
+        window.zone_file_editor.setVisible(bool(doc.zone_file_visible))
+    if hasattr(window, "zone_file_lbl"):
+        window.zone_file_lbl.setVisible(bool(doc.zone_file_visible))
+    if hasattr(window, "name_lbl") and getattr(doc, "object_label_text", ""):
+        window.name_lbl.setText(str(doc.object_label_text))
+    if hasattr(window, "arch_cb"):
+        window.arch_cb.setCurrentText(str(doc.quick_arch or ""))
+    if hasattr(window, "loadout_cb"):
+        window.loadout_cb.setCurrentText(str(doc.quick_loadout or ""))
+    if hasattr(window, "faction_cb"):
+        window.faction_cb.setCurrentText(str(doc.quick_faction or ""))
+    if hasattr(window, "rep_edit"):
+        window.rep_edit.setText(str(doc.quick_rep or ""))
+
+
+def restore_system_tab_state(window: Any, key: str | None = None) -> None:
+    spec = window._center_system_tab_spec(key)
+    if spec is None:
+        return
+    doc = spec.get("document")
+    apply_layout = getattr(window, "_apply_workspace_layout", None)
+    if callable(apply_layout):
+        apply_layout(
+            SimpleNamespace(
+                left_widget=_left_widget_for_mode(window, getattr(doc, "left_panel_mode", "ini")),
+                left_sidebar_visible=bool(getattr(doc, "left_sidebar_visible", True)),
+                right_panel_visible=bool(getattr(doc, "right_panel_visible", True)),
+                legend_visible=bool(getattr(doc, "legend_visible", True)),
+                zoom_controls_visible=bool(getattr(doc, "zoom_controls_visible", True)),
+                view3d_toggle_visible=bool(getattr(doc, "view3d_toggle_visible", True)),
+                view3d_toggle_enabled=bool(getattr(doc, "view3d_toggle_enabled", True)),
+                view3d_toggle_checked=bool(getattr(doc, "use_3d", False)),
+                sidebar_3d_enabled=bool(getattr(doc, "sidebar_3d_enabled", True)),
+            )
+        )
+    transform = getattr(doc, "view_transform", None)
+    if isinstance(transform, QTransform):
+        try:
+            window.view.setTransform(QTransform(transform))
+            if hasattr(window.view, "set_zoom_factor") and hasattr(window.view, "current_zoom_factor"):
+                window.view.set_zoom_factor(window.view.current_zoom_factor())
+            window._sync_zoom_slider_from_view(window.view.current_zoom_factor())
+        except Exception:
+            pass
+    selected_item = None
+    want_nick = str(getattr(doc, "selected_nickname", "") or "").strip().lower()
+    want_kind = str(getattr(doc, "selected_kind", "") or "").strip().lower()
+    if want_nick:
+        if want_kind == "zone":
+            selected_item = next((z for z in window._zones if z.nickname.strip().lower() == want_nick), None)
+            if selected_item is not None:
+                window._select_zone(selected_item)
+        else:
+            selected_item = next(
+                (o for o in window._objects if o.nickname.strip().lower() == want_nick and not hasattr(o, "sys_path")),
+                None,
+            )
+            if selected_item is not None:
+                window._select(selected_item)
+    use_3d = bool(getattr(doc, "use_3d", False))
+    window.view3d_switch.blockSignals(True)
+    window.view3d_switch.setChecked(use_3d)
+    window.view3d_switch.blockSignals(False)
+    if use_3d:
+        window._toggle_3d_view(True)
+    else:
+        center_set_current_widget = getattr(window, "_center_set_current_widget", None)
+        if callable(center_set_current_widget):
+            center_set_current_widget(getattr(window, "view", None), str(getattr(window, "_center_current_tab_key", "") or "").strip())
+    cam_state = getattr(doc, "camera_state", None)
+    if use_3d and isinstance(cam_state, dict) and hasattr(window.view3d, "set_camera_state"):
+        try:
+            window.view3d.set_camera_state(cam_state)
+        except Exception:
+            pass
+    if use_3d and selected_item is not None:
+        try:
+            window.view3d.set_selected(selected_item)
+        except Exception:
+            pass
+    _restore_system_tab_pending_state(window, doc)
+    restore_system_tab_editor_state(window, doc)
+
+
+def capture_system_tab_document(window: Any, key: str | None = None) -> None:
+    spec = window._center_system_tab_spec(key)
+    if spec is None or not window._filepath:
+        return
+    try:
+        doc = spec.get("document")
+        if doc is None or not hasattr(doc, "path"):
+            factory = getattr(window, "_system_document_factory", None)
+            if factory is None:
+                return
+            doc = factory(path=str(window._filepath))
+        doc.path = str(window._filepath)
+        saved_sections = build_saved_system_sections(
+            list(getattr(window, "_sections", []) or []),
+            list(getattr(window, "_objects", []) or []),
+            list(getattr(window, "_zones", []) or []),
+            extract_nickname_from_entries=window._extract_nickname_from_entries,
+        )
+        doc.sections = deepcopy(saved_sections)
+        doc.dirty = bool(window._dirty)
+        doc.change_snapshots = deepcopy(window._change_snapshots)
+        doc.last_snapshot_fp = str(window._last_snapshot_fp or "")
+        doc.history_restore_in_progress = bool(window._history_restore_in_progress)
+        doc.undo_actions = deepcopy(window._undo_actions)
+        doc.change_log_entries = list(window._change_log_entries)
+        doc.pending_zone = deepcopy(window._pending_zone)
+        doc.pending_simple_zone = deepcopy(window._pending_simple_zone)
+        doc.pending_exclusion_zone = deepcopy(window._pending_exclusion_zone)
+        doc.pending_light_source = deepcopy(window._pending_light_source)
+        doc.pending_template_object = deepcopy(window._pending_template_object)
+        doc.pending_buoy = deepcopy(window._pending_buoy)
+        doc.pending_create = deepcopy(window._pending_create)
+        doc.pending_new_object = bool(window._pending_new_object)
+        doc.pending_conn = deepcopy(window._pending_conn)
+        doc.pending_snapshots = deepcopy(window._pending_snapshots)
+        doc.pending_new_system = deepcopy(window._pending_new_system)
+        doc.pending_tradelane = deepcopy(window._pending_tradelane)
+        doc.pending_tl_reposition = deepcopy(window._pending_tl_reposition)
+        doc.pending_base = deepcopy(window._pending_base)
+        doc.pending_dock_ring = deepcopy(window._pending_dock_ring)
+        doc.pending_ring_attach = deepcopy(window._pending_ring_attach)
+        doc.pending_mode_text = str(window.mode_lbl.text() or "")
+        doc.left_panel_mode = _left_panel_mode(window)
+        doc.left_sidebar_visible = bool(window.left_stack.isVisible()) if hasattr(window, "left_stack") else True
+        doc.right_panel_visible = bool(window.right_panel.isVisible()) if hasattr(window, "right_panel") else True
+        doc.legend_visible = bool(window.legend_box.isVisible()) if hasattr(window, "legend_box") else True
+        doc.zoom_controls_visible = bool(window._menu_zoom_host.isVisible()) if hasattr(window, "_menu_zoom_host") else True
+        doc.view3d_toggle_visible = bool(window.view3d_switch.isVisible()) if hasattr(window, "view3d_switch") else True
+        doc.view3d_toggle_enabled = bool(window.view3d_switch.isEnabled()) if hasattr(window, "view3d_switch") else True
+        doc.sidebar_3d_enabled = bool(window._sidebar_3d_btn.isEnabled()) if hasattr(window, "_sidebar_3d_btn") else True
+        doc.editor_text = window.editor.toPlainText() if hasattr(window, "editor") else ""
+        doc.editor_cursor_pos = int(window.editor.textCursor().position()) if hasattr(window, "editor") else 0
+        doc.editor_visible = bool(window.editor.isVisible()) if hasattr(window, "editor") else True
+        doc.apply_visible = bool(window.apply_btn.isVisible()) if hasattr(window, "apply_btn") else True
+        doc.zone_link_text = window.zone_link_editor.toPlainText() if hasattr(window, "zone_link_editor") else ""
+        doc.zone_link_visible = bool(window.zone_link_editor.isVisible()) if hasattr(window, "zone_link_editor") else False
+        doc.zone_file_text = window.zone_file_editor.toPlainText() if hasattr(window, "zone_file_editor") else ""
+        doc.zone_file_visible = bool(window.zone_file_editor.isVisible()) if hasattr(window, "zone_file_editor") else False
+        doc.object_label_text = window.name_lbl.text() if hasattr(window, "name_lbl") else ""
+        doc.quick_arch = window.arch_cb.currentText() if hasattr(window, "arch_cb") else ""
+        doc.quick_loadout = window.loadout_cb.currentText() if hasattr(window, "loadout_cb") else ""
+        doc.quick_faction = window.faction_cb.currentText() if hasattr(window, "faction_cb") else ""
+        doc.quick_rep = window.rep_edit.text() if hasattr(window, "rep_edit") else ""
+        spec["document"] = doc
+    except Exception:
+        pass
+
+
+def center_update_current_system_tab_title(window: Any) -> None:
+    key = str(window._center_current_tab_key or "").strip()
+    if not key.startswith("system:") or not window._filepath:
+        return
+    idx = window._center_tab_index_for_key(key)
+    if idx < 0:
+        return
+    base_title = window._system_tab_title(window._filepath)
+    window._center_tab_specs[idx]["title"] = apply_dirty_system_tab_title(base_title, window._dirty)
+    window._center_sync_tab_bar()
+
+
+def preserve_active_system_tab_document(window: Any) -> None:
+    key = str(window._center_current_tab_key or "").strip()
+    if not key.startswith("system:"):
+        return
+    capture_system_tab_state(window, key)
+    capture_system_tab_document(window, key)

--- a/tests/test_system_document_runtime.py
+++ b/tests/test_system_document_runtime.py
@@ -1,0 +1,532 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from PySide6.QtCore import QPointF, QRectF
+from PySide6.QtGui import QTransform
+
+from fl_editor import system_document_runtime as runtime
+
+
+class _Scene:
+    def __init__(self):
+        self.items = []
+        self.cleared = 0
+        self.scene_rects = []
+
+    def clear(self):
+        self.cleared += 1
+        self.items.clear()
+
+    def setSceneRect(self, *rect):
+        self.scene_rects.append(rect)
+
+    def addItem(self, item):
+        self.items.append(item)
+
+
+class _View:
+    def __init__(self):
+        self._scene = _Scene()
+        self.world_scale = None
+        self.zoom_out_limit = None
+        self.zoom_out_reference_rect = None
+        self.zoom_in_limit_multiplier = None
+        self.unbounded_pan = None
+        self.left_drag_pan = None
+        self.transform_value = None
+        self.centered_on = None
+
+    def set_world_scale(self, scale):
+        self.world_scale = scale
+
+    def set_zoom_out_limit_to_scene(self, value):
+        self.zoom_out_limit = bool(value)
+
+    def set_zoom_out_reference_rect(self, rect):
+        self.zoom_out_reference_rect = rect
+
+    def set_zoom_in_limit_multiplier(self, value):
+        self.zoom_in_limit_multiplier = float(value)
+
+    def set_unbounded_pan(self, value):
+        self.unbounded_pan = bool(value)
+
+    def set_left_drag_pan_enabled(self, value):
+        self.left_drag_pan = bool(value)
+
+    def setTransform(self, transform):
+        self.transform_value = transform
+
+    def centerOn(self, point):
+        self.centered_on = point
+
+    def current_zoom_factor(self):
+        return 1.5
+
+
+class _Toggle:
+    def __init__(self, checked=False):
+        self._checked = bool(checked)
+
+    def isChecked(self):
+        return self._checked
+
+
+class _Parser:
+    def __init__(self, objects=None, zones=None, parsed=None):
+        self._objects = list(objects or [])
+        self._zones = list(zones or [])
+        self._parsed = list(parsed or [])
+        self.parse_calls = []
+
+    def get_objects(self, _sections):
+        return list(self._objects)
+
+    def get_zones(self, _sections):
+        return list(self._zones)
+
+    def parse(self, path):
+        self.parse_calls.append(path)
+        return list(self._parsed)
+
+
+class _Label:
+    def __init__(self):
+        self.text = ""
+
+    def setPlainText(self, text):
+        self.text = str(text)
+
+
+class _FakeSolarObject:
+    _top_view_icon_auto_refresh_enabled = True
+    auto_refresh_history: list[bool] = []
+
+    def __init__(self, data, scale):
+        self.data = dict(data)
+        self.scale = scale
+        self.nickname = str(data.get("nickname", ""))
+        self.label = _Label()
+        self.flags = []
+        self.visible_labels = []
+        self.refresh_calls = 0
+        self.auto_refresh_used = bool(type(self)._top_view_icon_auto_refresh_enabled)
+        type(self).auto_refresh_history.append(self.auto_refresh_used)
+
+    def set_label_visibility(self, visible):
+        self.visible_labels.append(bool(visible))
+
+    def setFlag(self, flag, enabled):
+        self.flags.append((flag, bool(enabled)))
+
+    @classmethod
+    def set_top_view_icon_auto_refresh_enabled(cls, enabled):
+        cls._top_view_icon_auto_refresh_enabled = bool(enabled)
+
+    def refresh_top_view_icon(self):
+        self.refresh_calls += 1
+
+
+class _FakeZoneItem:
+    def __init__(self, data, scale):
+        self.data = dict(data)
+        self.scale = scale
+        self.visible_labels = []
+
+    def set_label_visibility(self, visible):
+        self.visible_labels.append(bool(visible))
+
+
+class _Action:
+    def __init__(self):
+        self.visible = None
+        self.enabled = None
+
+    def setVisible(self, value):
+        self.visible = bool(value)
+
+    def setEnabled(self, value):
+        self.enabled = bool(value)
+
+
+class _TextHolder:
+    def __init__(self):
+        self.text = ""
+
+    def setText(self, text):
+        self.text = str(text)
+
+
+class _StatusBar:
+    def __init__(self):
+        self.message = ""
+
+    def showMessage(self, message):
+        self.message = str(message)
+
+
+class _Doc:
+    def __init__(self):
+        self.change_snapshots = [{"x": 1}]
+        self.last_snapshot_fp = "snap.json"
+        self.history_restore_in_progress = True
+        self.undo_actions = ["undo"]
+        self.change_log_entries = ["log"]
+        self.pending_zone = {"kind": "zone"}
+
+
+def _build_window(*, parser=None):
+    window = SimpleNamespace()
+    window._parser = parser or _Parser()
+    window._viewer_text_visible = True
+    window._avoid_label_overlap = False
+    window._objects = []
+    window._zones = []
+    window._selected = None
+    window._filepath = ""
+    window._sections = []
+    window._dirty = False
+    window._change_snapshots = []
+    window._last_snapshot_fp = ""
+    window._history_restore_in_progress = False
+    window._undo_actions = []
+    window._change_log_entries = []
+    window._flight_lock_active = False
+    window._pending_conn = {"old": 1}
+    window._pending_create = {"old": 1}
+    window._pending_light_source = {"old": 1}
+    window._pending_new_object = True
+    window._pending_tradelane = {"old": 1}
+    window._pending_tl_reposition = {"old": 1}
+    window.view = _View()
+    window.move_cb = _Toggle(True)
+    window.view3d_switch = _Toggle(True)
+    window.left_ini_panel = object()
+    window._workspace_layout_state_factory = lambda **kwargs: SimpleNamespace(**kwargs)
+    window.info_lbl = _TextHolder()
+    window._sys_header_lbl = _TextHolder()
+    window.status = _StatusBar()
+    window.statusBar = lambda: window.status
+    window._new_system_action = _Action()
+    window._uni_save_action = _Action()
+    window._uni_undo_action = _Action()
+    window._uni_delete_action = _Action()
+    window.uni_delete_btn = _Action()
+    window._ids_scan_action = _Action()
+    window._ids_import_action = _Action()
+    window._change_undo_btn = _Action()
+    window.change_log_view = SimpleNamespace(setPlainText=lambda text: setattr(window, "change_log_text", text))
+    window._set_system_zoom_controls_visible = lambda value: setattr(window, "zoom_controls_visible", bool(value))
+    window._clear_move_delta_indicator = lambda: setattr(window, "move_delta_cleared", True)
+    window._apply_scene_wallpaper = lambda: setattr(window, "wallpaper_applied", True)
+    window._clear_selection_ui = lambda: setattr(window, "selection_cleared", True)
+    window._hide_zone_extra_editors = lambda: setattr(window, "zone_editors_hidden", True)
+    window._object_display_label = lambda obj: f"label:{obj.nickname}"
+    window._draw_system_reference_overlay = lambda radius: setattr(window, "overlay_radius", radius)
+    window._system_zoom_reference_rect = lambda radius: QRectF(-radius * 1.25, -radius * 1.25, radius * 2.5, radius * 2.5)
+    window._apply_group_visibility = lambda: setattr(window, "group_visibility_applied", True)
+    window._reflow_2d_labels = lambda: setattr(window, "labels_reflowed", True)
+    window._reset_2d_label_positions = lambda: setattr(window, "labels_reset", True)
+    window._system_nickname_for_path = lambda path: "li01"
+    window._system_display_name = lambda nick: f"System {nick.upper()}"
+    window._format_system_header_text = lambda nick: f"Header {nick}"
+    window._rebuild_object_combo = lambda: setattr(window, "object_combo_rebuilt", True)
+    window._update_base_child_interactivity = lambda: setattr(window, "base_child_interactivity_updated", True)
+    window._title_with_version = lambda text: f"title::{text}"
+    window.setWindowTitle = lambda text: setattr(window, "window_title", text)
+    window._apply_workspace_layout = lambda state: setattr(window, "workspace_state", state)
+    window._set_global_nav_active = lambda key: setattr(window, "nav_key", key)
+    window._set_dirty = lambda value: setattr(window, "_dirty", bool(value))
+    window._fit = lambda: setattr(window, "fit_called", True)
+    window._sync_zoom_slider_from_view = lambda zoom: setattr(window, "synced_zoom", zoom)
+    window._refresh_3d_scene = lambda *args, **kwargs: setattr(
+        window,
+        "scene_refreshed",
+        {"args": args, "kwargs": kwargs},
+    )
+    window._refresh_viewer_move_border = lambda: setattr(window, "move_border_refreshed", True)
+    window._populate_quick_editor_options = lambda: setattr(window, "quick_options_populated", True)
+    window._populate_system_options = lambda: setattr(window, "system_options_populated", True)
+    window._build_standard_menu_bar = lambda: setattr(window, "menu_built", True)
+    window._refresh_system_fields = lambda: setattr(window, "system_fields_refreshed", True)
+    window._collect_change_log_lines = lambda: ["one", "two"]
+    window._reload_dll_name_cache = lambda: setattr(window, "dll_cache_reloaded", True)
+    window._restore_system_tab_pending_state = lambda doc: setattr(window, "restored_pending_doc", doc)
+    window._set_loading_visible = lambda visible, text=None: setattr(
+        window,
+        "loading_calls",
+        getattr(window, "loading_calls", []) + [(bool(visible), text)],
+    )
+    window._set_flight_mode = lambda enabled: setattr(window, "flight_mode", bool(enabled))
+    window._set_placement_mode = lambda enabled, text="": setattr(window, "placement_mode", (bool(enabled), text))
+    window._apply_system_document = lambda path, sections, restore=None, dirty=False: setattr(
+        window,
+        "applied_document",
+        {"path": path, "sections": sections, "restore": restore, "dirty": dirty},
+    )
+    return window
+
+
+def test_apply_system_document_rebuilds_scene_and_restores_runtime_state(monkeypatch):
+    parser = _Parser(
+        objects=[{"nickname": "sun", "pos": "1000,0,2000", "size": "50"}],
+        zones=[{"nickname": "zone_a"}],
+    )
+    window = _build_window(parser=parser)
+    doc = _Doc()
+    restore = QTransform()
+    single_shot_calls: list[int] = []
+
+    def _fake_single_shot(delay: int, callback):
+        single_shot_calls.append(int(delay))
+        callback()
+
+    _FakeSolarObject.auto_refresh_history = []
+    _FakeSolarObject._top_view_icon_auto_refresh_enabled = True
+    monkeypatch.setattr(runtime, "SolarObject", _FakeSolarObject)
+    monkeypatch.setattr(runtime, "ZoneItem", _FakeZoneItem)
+    monkeypatch.setattr(runtime.QTimer, "singleShot", staticmethod(_fake_single_shot))
+
+    runtime.apply_system_document(
+        window,
+        "C:/mods/DATA/UNIVERSE/li01.ini",
+        [("system", [("nickname", "li01")])],
+        restore=restore,
+        dirty=True,
+        doc=doc,
+    )
+
+    assert window._filepath.endswith("li01.ini")
+    assert window._change_snapshots == [{"x": 1}]
+    assert window._undo_actions == ["undo"]
+    assert window.restored_pending_doc is doc
+    assert window.view.world_scale == 0.05
+    assert window.view.zoom_out_limit is True
+    assert window.view.zoom_out_reference_rect == QRectF(
+        -2857.5849718747377,
+        -2857.5849718747377,
+        5715.1699437494755,
+        5715.1699437494755,
+    )
+    assert window.view.zoom_in_limit_multiplier == 40.0
+    assert len(window._zones) == 1
+    assert len(window._objects) == 1
+    assert window._objects[0].label.text == "label:sun"
+    assert window.overlay_radius == 2286.06797749979
+    assert window.workspace_state.right_panel_visible is True
+    assert window.object_combo_rebuilt is True
+    assert window.scene_refreshed == {"args": (), "kwargs": {"preserve_camera": True}}
+    assert window.change_log_text == "one\ntwo"
+    assert window._dirty is True
+    assert window.synced_zoom == 1.5
+    assert window.loading_calls == [(True, runtime.tr("status.preparing_system_view")), (False, None)]
+    assert single_shot_calls == [0]
+    assert _FakeSolarObject.auto_refresh_history == [False]
+
+
+def test_apply_system_document_queues_top_view_icon_refresh_after_scene_rebuild(monkeypatch):
+    parser = _Parser(
+        objects=[
+            {"nickname": "sun", "pos": "1000,0,2000", "size": "50"},
+            {"nickname": "planet", "pos": "0,0,0", "size": "500"},
+        ],
+        zones=[{"nickname": "zone_a"}],
+    )
+    window = _build_window(parser=parser)
+    queued_objects: list[list[object]] = []
+    window._queue_top_view_icon_refresh = lambda objs: queued_objects.append(list(objs))
+
+    def _fake_single_shot(delay: int, callback):
+        callback()
+
+    _FakeSolarObject.auto_refresh_history = []
+    _FakeSolarObject._top_view_icon_auto_refresh_enabled = True
+    monkeypatch.setattr(runtime, "SolarObject", _FakeSolarObject)
+    monkeypatch.setattr(runtime, "ZoneItem", _FakeZoneItem)
+    monkeypatch.setattr(runtime.QTimer, "singleShot", staticmethod(_fake_single_shot))
+
+    runtime.apply_system_document(
+        window,
+        "C:/mods/DATA/UNIVERSE/li01.ini",
+        [("system", [("nickname", "li01")])],
+        restore=None,
+        dirty=False,
+        doc=None,
+    )
+
+    assert len(window._objects) == 2
+    assert queued_objects == [window._objects]
+    assert all(obj.refresh_calls == 0 for obj in window._objects)
+    assert _FakeSolarObject.auto_refresh_history == [False, False]
+
+
+def test_apply_system_document_does_not_clear_pending_connection_without_tab_document(monkeypatch):
+    parser = _Parser(
+        objects=[{"nickname": "sun", "pos": "1000,0,2000", "size": "50"}],
+        zones=[],
+    )
+    window = _build_window(parser=parser)
+    window._pending_conn = {"step": 2, "origin": "li01"}
+
+    def _unexpected_restore(_doc):
+        raise AssertionError("pending placement state should not be restored from a missing document")
+
+    monkeypatch.setattr(runtime, "SolarObject", _FakeSolarObject)
+    monkeypatch.setattr(runtime, "ZoneItem", _FakeZoneItem)
+    monkeypatch.setattr(runtime.QTimer, "singleShot", staticmethod(lambda _delay, callback: callback()))
+    window._restore_system_tab_pending_state = _unexpected_restore
+
+    runtime.apply_system_document(
+        window,
+        "C:/mods/DATA/UNIVERSE/br01.ini",
+        [("system", [("nickname", "br01")])],
+        restore=None,
+        dirty=False,
+        doc=None,
+    )
+
+    assert window._pending_conn == {"step": 2, "origin": "li01"}
+
+
+def test_apply_system_document_keeps_loading_visible_until_deferred_post_load_finishes(monkeypatch):
+    parser = _Parser(
+        objects=[{"nickname": "sun", "pos": "1000,0,2000", "size": "50"}],
+        zones=[{"nickname": "zone_a"}],
+    )
+    window = _build_window(parser=parser)
+    window.view3d_switch = _Toggle(False)
+    window._primary_game_path = lambda: "C:/Freelancer"
+    quick_calls: list[str] = []
+    window._populate_quick_editor_options = lambda game_path: quick_calls.append(str(game_path))
+
+    single_shot_calls: list[int] = []
+
+    def _fake_single_shot(delay: int, callback):
+        single_shot_calls.append(int(delay))
+        callback()
+
+    monkeypatch.setattr(runtime, "SolarObject", _FakeSolarObject)
+    monkeypatch.setattr(runtime, "ZoneItem", _FakeZoneItem)
+    monkeypatch.setattr(runtime.QTimer, "singleShot", staticmethod(_fake_single_shot))
+
+    runtime.apply_system_document(
+        window,
+        "C:/mods/DATA/UNIVERSE/li01.ini",
+        [("system", [("nickname", "li01")])],
+        restore=None,
+        dirty=False,
+        doc=None,
+    )
+
+    assert single_shot_calls == [0]
+    assert quick_calls == ["C:/Freelancer"]
+    assert window.loading_calls == [(True, runtime.tr("status.preparing_system_view")), (False, None)]
+
+
+def test_apply_system_document_preserves_camera_during_deferred_3d_refresh(monkeypatch):
+    parser = _Parser(
+        objects=[{"nickname": "sun", "pos": "1000,0,2000", "size": "50"}],
+        zones=[{"nickname": "zone_a"}],
+    )
+    window = _build_window(parser=parser)
+    refresh_calls: list[dict[str, object]] = []
+    window._refresh_3d_scene = lambda *args, **kwargs: refresh_calls.append({"args": args, "kwargs": kwargs})
+
+    monkeypatch.setattr(runtime, "SolarObject", _FakeSolarObject)
+    monkeypatch.setattr(runtime, "ZoneItem", _FakeZoneItem)
+    monkeypatch.setattr(runtime.QTimer, "singleShot", staticmethod(lambda _delay, callback: callback()))
+
+    runtime.apply_system_document(
+        window,
+        "C:/mods/DATA/UNIVERSE/li01.ini",
+        [("system", [("nickname", "li01")])],
+        restore=None,
+        dirty=False,
+        doc=None,
+    )
+
+    assert refresh_calls == [{"args": (), "kwargs": {"preserve_camera": True}}]
+
+
+def test_load_system_resets_pending_state_and_delegates_to_apply():
+    parser = _Parser(parsed=[("system", [("nickname", "li01")])])
+    window = _build_window(parser=parser)
+    window._flight_lock_active = True
+    restore = QTransform()
+
+    runtime.load_system(window, "C:/mods/DATA/UNIVERSE/li01.ini", restore=restore)
+
+    assert window.flight_mode is False
+    assert window._pending_conn is None
+    assert window._pending_create is None
+    assert window._pending_light_source is None
+    assert window._pending_new_object is False
+    assert window._pending_tradelane is None
+    assert window._pending_tl_reposition is None
+    assert window.placement_mode == (False, "")
+    assert parser.parse_calls == ["C:/mods/DATA/UNIVERSE/li01.ini"]
+    assert window.applied_document == {
+        "path": "C:/mods/DATA/UNIVERSE/li01.ini",
+        "sections": [("system", [("nickname", "li01")])],
+        "restore": restore,
+        "dirty": False,
+    }
+    assert window.loading_calls == [(True, runtime.tr("status.loading_system")), (False, None)]
+
+
+def test_collect_system_document_payload_uses_window_boundary_resolver():
+    parser = _Parser(
+        objects=[
+            {
+                "nickname": "Li01_Beam_Target",
+                "archetype": "jumphole",
+                "base": "Li01_Beam_Target",
+                "dock_with": "Li01_Beam_Target",
+                "pos": "0, 0, 1000000",
+            }
+        ],
+        zones=[],
+        parsed=[("LightSource", [("nickname", "li01_system_light"), ("range", "120000"), ("type", "DIRECTIONAL")])],
+    )
+    window = _build_window(parser=parser)
+    seen_raw_objects: list[list[dict[str, object]]] = []
+    window._resolve_system_boundary_radius_world = lambda path, sections=None, raw_objects=None: 44117.64705882353
+
+    def _record_resolver(path, sections=None, raw_objects=None):
+        seen_raw_objects.append(list(raw_objects or []))
+        return 44117.64705882353
+
+    window._resolve_system_boundary_radius_world = _record_resolver
+
+    payload = runtime.collect_system_document_payload(window, "C:/mods/DATA/UNIVERSE/li01.ini")
+
+    assert payload["boundary_radius"] == pytest.approx(44117.64705882353)
+    assert payload["raw_objects"] == []
+    assert seen_raw_objects == [[]]
+
+
+def test_apply_system_document_restores_view_center_from_restore_payload(monkeypatch):
+    parser = _Parser(objects=[{"nickname": "sun", "pos": "1000,0,2000", "size": "50"}], zones=[])
+    window = _build_window(parser=parser)
+    restore = {
+        "transform": QTransform(),
+        "center_scene": QPointF(125.0, -340.0),
+    }
+
+    monkeypatch.setattr(runtime, "SolarObject", _FakeSolarObject)
+    monkeypatch.setattr(runtime, "ZoneItem", _FakeZoneItem)
+    monkeypatch.setattr(runtime.QTimer, "singleShot", staticmethod(lambda _delay, callback: callback()))
+
+    runtime.apply_system_document(
+        window,
+        "C:/mods/DATA/UNIVERSE/li01.ini",
+        [("system", [("nickname", "li01")])],
+        restore=restore,
+        dirty=False,
+        doc=None,
+    )
+
+    assert window.view.transform_value == restore["transform"]
+    assert window.view.centered_on == restore["center_scene"]

--- a/tests/test_system_tab_document_runtime.py
+++ b/tests/test_system_tab_document_runtime.py
@@ -1,0 +1,408 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from PySide6.QtGui import QTransform
+
+from fl_editor.system_tab_document_runtime import (
+    capture_system_tab_document,
+    capture_system_tab_state,
+    center_update_current_system_tab_title,
+    preserve_active_system_tab_document,
+    restore_system_tab_state,
+)
+
+
+class _Doc:
+    def __init__(self, path: str = ""):
+        self.path = path
+        self.sections = []
+        self.dirty = False
+        self.change_snapshots = []
+        self.last_snapshot_fp = ""
+        self.history_restore_in_progress = False
+        self.undo_actions = []
+        self.change_log_entries = []
+        self.pending_zone = None
+        self.pending_simple_zone = None
+        self.pending_exclusion_zone = None
+        self.pending_light_source = None
+        self.pending_template_object = None
+        self.pending_buoy = None
+        self.pending_create = None
+        self.pending_new_object = False
+        self.pending_conn = None
+        self.pending_snapshots = []
+        self.pending_new_system = None
+        self.pending_tradelane = None
+        self.pending_tl_reposition = None
+        self.pending_base = None
+        self.pending_dock_ring = None
+        self.pending_ring_attach = None
+        self.pending_mode_text = ""
+        self.left_panel_mode = ""
+        self.left_sidebar_visible = True
+        self.right_panel_visible = True
+        self.legend_visible = True
+        self.zoom_controls_visible = True
+        self.view3d_toggle_visible = True
+        self.view3d_toggle_enabled = True
+        self.sidebar_3d_enabled = True
+        self.editor_text = ""
+        self.editor_cursor_pos = 0
+        self.editor_visible = True
+        self.apply_visible = True
+        self.zone_link_text = ""
+        self.zone_link_visible = False
+        self.zone_file_text = ""
+        self.zone_file_visible = False
+        self.object_label_text = ""
+        self.quick_arch = ""
+        self.quick_loadout = ""
+        self.quick_faction = ""
+        self.quick_rep = ""
+        self.view_transform = None
+        self.use_3d = False
+        self.camera_state = None
+        self.selected_kind = ""
+        self.selected_nickname = ""
+
+
+class _TextCursor:
+    def __init__(self, position: int = 0):
+        self._position = int(position)
+
+    def position(self):
+        return self._position
+
+    def setPosition(self, value: int):
+        self._position = int(value)
+
+
+class _Editor:
+    def __init__(self, text: str = "", visible: bool = True):
+        self._text = text
+        self._visible = visible
+        self._cursor = _TextCursor()
+
+    def toPlainText(self):
+        return self._text
+
+    def setPlainText(self, text: str):
+        self._text = str(text)
+
+    def isVisible(self):
+        return self._visible
+
+    def setVisible(self, visible: bool):
+        self._visible = bool(visible)
+
+    def textCursor(self):
+        return self._cursor
+
+    def setTextCursor(self, cursor):
+        self._cursor = cursor
+
+
+class _VisibleWidget:
+    def __init__(self, visible: bool = True, enabled: bool = True):
+        self._visible = bool(visible)
+        self._enabled = bool(enabled)
+
+    def isVisible(self):
+        return self._visible
+
+    def setVisible(self, visible: bool):
+        self._visible = bool(visible)
+
+    def isEnabled(self):
+        return self._enabled
+
+    def setEnabled(self, enabled: bool):
+        self._enabled = bool(enabled)
+
+
+class _LineEdit:
+    def __init__(self, text: str = ""):
+        self._text = text
+
+    def text(self):
+        return self._text
+
+    def setText(self, text: str):
+        self._text = str(text)
+
+
+class _Combo:
+    def __init__(self, text: str = ""):
+        self._text = text
+
+    def currentText(self):
+        return self._text
+
+    def setCurrentText(self, text: str):
+        self._text = str(text)
+
+
+class _Switch:
+    def __init__(self, checked: bool = False, visible: bool = True, enabled: bool = True):
+        self.checked = bool(checked)
+        self.visible = bool(visible)
+        self.enabled = bool(enabled)
+        self.blocked = []
+
+    def isChecked(self):
+        return self.checked
+
+    def setChecked(self, value: bool):
+        self.checked = bool(value)
+
+    def blockSignals(self, value: bool):
+        self.blocked.append(bool(value))
+
+    def isVisible(self):
+        return self.visible
+
+    def isEnabled(self):
+        return self.enabled
+
+
+class _View:
+    def __init__(self):
+        self._transform = QTransform()
+
+    def transform(self):
+        return self._transform
+
+    def setTransform(self, transform):
+        self._transform = QTransform(transform)
+
+    def current_zoom_factor(self):
+        return 1.0
+
+
+class _LeftStack:
+    def __init__(self, current=None, visible: bool = True):
+        self._current = current
+        self._visible = bool(visible)
+
+    def currentWidget(self):
+        return self._current
+
+    def setCurrentWidget(self, widget):
+        self._current = widget
+
+    def isVisible(self):
+        return self._visible
+
+    def setVisible(self, visible: bool):
+        self._visible = bool(visible)
+
+
+class _CenterStack:
+    def __init__(self, current=None):
+        self._current = current
+
+    def currentWidget(self):
+        return self._current
+
+    def setCurrentWidget(self, widget):
+        self._current = widget
+
+
+def _build_window():
+    spec = {"key": "system:li01", "document": None}
+    selected = SimpleNamespace(
+        nickname="Li01",
+        data={"_entries": [("nickname", "Li01"), ("pos", "0, 0, 0")]},
+        __class__=SimpleNamespace,
+    )
+    window = SimpleNamespace()
+    window._filepath = "C:/mods/DATA/UNIVERSE/li01.ini"
+    window._sections = [("system", [("nickname", "li01")])]
+    window._dirty = True
+    window._change_snapshots = [{"a": 1}]
+    window._last_snapshot_fp = "snap.json"
+    window._history_restore_in_progress = False
+    window._undo_actions = ["undo"]
+    window._change_log_entries = ["changed"]
+    window._pending_zone = {"zone": 1}
+    window._pending_simple_zone = None
+    window._pending_exclusion_zone = None
+    window._pending_light_source = None
+    window._pending_template_object = None
+    window._pending_buoy = None
+    window._pending_create = None
+    window._pending_new_object = True
+    window._pending_conn = {"conn": 1}
+    window._pending_snapshots = [1]
+    window._pending_new_system = {"sys": 1}
+    window._pending_tradelane = {"tl": 1}
+    window._pending_tl_reposition = {"move": 1}
+    window._pending_base = {"base": 1}
+    window._pending_dock_ring = {"dock": 1}
+    window._pending_ring_attach = {"ring": 1}
+    window.mode_lbl = SimpleNamespace(_text="place", text=lambda: "place", setText=lambda text: setattr(window.mode_lbl, "_text", text))
+    window.editor = _Editor("editor text", True)
+    window.editor.textCursor().setPosition(4)
+    window.apply_btn = SimpleNamespace(isVisible=lambda: True, setVisible=lambda value: setattr(window, "apply_visible", bool(value)))
+    window.zone_link_editor = _Editor("zone link", True)
+    window.zone_link_lbl = SimpleNamespace(setVisible=lambda value: setattr(window, "zone_link_lbl_visible", bool(value)))
+    window.zone_file_editor = _Editor("zone file", False)
+    window.zone_file_lbl = SimpleNamespace(setVisible=lambda value: setattr(window, "zone_file_lbl_visible", bool(value)))
+    window.name_lbl = SimpleNamespace(text=lambda: "Object", setText=lambda text: setattr(window, "name_label", text))
+    window.arch_cb = _Combo("arch")
+    window.loadout_cb = _Combo("loadout")
+    window.faction_cb = _Combo("faction")
+    window.rep_edit = _LineEdit("0.9")
+    window._system_document_factory = _Doc
+    window._center_current_tab_key = "system:li01"
+    window._center_tab_specs = [spec]
+    window._center_system_tab_spec = lambda key=None: spec
+    window.view = _View()
+    window.center_stack = _CenterStack(window.view)
+    window.view3d_switch = _Switch(True)
+    window.view3d = SimpleNamespace(
+        get_camera_state=lambda: {"cam": 1},
+        set_camera_state=lambda state: setattr(window, "restored_camera_state", state),
+        set_selected=lambda item: setattr(window, "view3d_selected", item),
+    )
+    window._selected = selected
+    window._objects = [selected]
+    window._zones = []
+    window._sync_zoom_slider_from_view = lambda zoom: setattr(window, "synced_zoom", zoom)
+    window._select = lambda item: setattr(window, "selected_object", item)
+    window._select_zone = lambda item: setattr(window, "selected_zone", item)
+    window._toggle_3d_view = lambda enabled: setattr(window, "toggle_3d", bool(enabled))
+    window._center_set_current_widget = lambda widget, key=None: (
+        window.center_stack.setCurrentWidget(widget),
+        setattr(window, "center_widget_key", key),
+    )
+    window._clear_pending_visual_helpers = lambda: setattr(window, "pending_visuals_cleared", True)
+    window.save_conn_btn = SimpleNamespace(setVisible=lambda value: setattr(window, "save_conn_visible", bool(value)))
+    window.create_conn_btn = SimpleNamespace(setEnabled=lambda value: setattr(window, "create_conn_enabled", bool(value)))
+    window._has_pending_placement = lambda: True
+    window._set_placement_mode = lambda enabled, _text="": setattr(window, "placement_mode", bool(enabled))
+    window.browser = object()
+    window.left_ini_panel = object()
+    window.left_uni_panel = object()
+    window.left_trade_panel = object()
+    window.left_name_panel = object()
+    window.left_stack = _LeftStack(window.left_ini_panel, True)
+    window.right_panel = _VisibleWidget(True)
+    window.legend_box = _VisibleWidget(True)
+    window._menu_zoom_host = _VisibleWidget(True)
+    window._sidebar_3d_btn = _VisibleWidget(True, True)
+    window._apply_workspace_layout = lambda state: setattr(window, "applied_layout", state)
+    window._center_tab_index_for_key = lambda key: 0
+    window._system_tab_title = lambda path: f"System::{path}"
+    window._center_sync_tab_bar = lambda: setattr(window, "tab_bar_synced", True)
+    window._extract_nickname_from_entries = lambda entries: next((value for key, value in entries if str(key).lower() == "nickname"), None)
+    return window
+
+
+def test_capture_system_tab_document_and_state_store_values():
+    window = _build_window()
+
+    capture_system_tab_state(window)
+    capture_system_tab_document(window)
+
+    doc = window._center_tab_specs[0]["document"]
+    assert isinstance(doc, _Doc)
+    assert isinstance(doc.view_transform, QTransform)
+    assert doc.use_3d is True
+    assert doc.camera_state == {"cam": 1}
+    assert doc.selected_nickname == "Li01"
+    assert doc.editor_text == "editor text"
+    assert doc.editor_cursor_pos == 4
+    assert doc.quick_arch == "arch"
+    assert doc.pending_new_object is True
+    assert doc.pending_ring_attach == {"ring": 1}
+    assert doc.left_panel_mode == "ini"
+    assert doc.left_sidebar_visible is True
+    assert doc.sections[-1] == ("Object", [("nickname", "Li01"), ("pos", "0, 0, 0")])
+
+
+def test_restore_system_tab_state_applies_selection_camera_and_editor_state():
+    window = _build_window()
+    doc = _Doc(path=window._filepath)
+    doc.view_transform = QTransform()
+    doc.use_3d = True
+    doc.camera_state = {"cam": 2}
+    doc.selected_kind = "object"
+    doc.selected_nickname = "li01"
+    doc.pending_snapshots = [1]
+    doc.pending_ring_attach = {"ring": 2}
+    doc.pending_mode_text = "placing"
+    doc.editor_text = "restored"
+    doc.editor_cursor_pos = 3
+    doc.editor_visible = True
+    doc.apply_visible = True
+    doc.zone_link_text = "zl"
+    doc.zone_link_visible = True
+    doc.zone_file_text = "zf"
+    doc.zone_file_visible = True
+    doc.object_label_text = "Label"
+    doc.quick_arch = "arch2"
+    doc.quick_loadout = "load2"
+    doc.quick_faction = "fac2"
+    doc.quick_rep = "1.0"
+    doc.left_panel_mode = "browser"
+    doc.left_sidebar_visible = True
+    doc.right_panel_visible = False
+    doc.legend_visible = False
+    doc.zoom_controls_visible = True
+    doc.view3d_toggle_visible = True
+    doc.view3d_toggle_enabled = True
+    doc.sidebar_3d_enabled = False
+    window._center_tab_specs[0]["document"] = doc
+
+    restore_system_tab_state(window)
+
+    assert window.synced_zoom == 1.0
+    assert window.selected_object.nickname == "Li01"
+    assert window.toggle_3d is True
+    assert window.restored_camera_state == {"cam": 2}
+    assert window.view3d_selected.nickname == "Li01"
+    assert window.pending_visuals_cleared is True
+    assert window.save_conn_visible is True
+    assert window.create_conn_enabled is False
+    assert window._pending_ring_attach == {"ring": 2}
+    assert window.placement_mode is True
+    assert window.applied_layout.left_widget is window.browser
+    assert window.applied_layout.right_panel_visible is False
+    assert window.applied_layout.legend_visible is False
+    assert window.applied_layout.sidebar_3d_enabled is False
+    assert window.editor.toPlainText() == "restored"
+    assert window.arch_cb.currentText() == "arch2"
+    assert window.rep_edit.text() == "1.0"
+
+
+def test_restore_system_tab_state_keeps_restored_2d_view_without_syncing_from_3d_camera():
+    window = _build_window()
+    doc = _Doc(path=window._filepath)
+    doc.view_transform = QTransform()
+    doc.use_3d = False
+    doc.selected_kind = "object"
+    doc.selected_nickname = "li01"
+    window._center_tab_specs[0]["document"] = doc
+
+    restore_system_tab_state(window)
+
+    assert not hasattr(window, "toggle_3d")
+    assert window.center_stack.currentWidget() is window.view
+    assert window.center_widget_key == "system:li01"
+
+
+def test_title_and_preserve_helpers_use_active_system_key():
+    window = _build_window()
+
+    center_update_current_system_tab_title(window)
+    preserve_active_system_tab_document(window)
+
+    assert "System::" in window._center_tab_specs[0]["title"]
+    assert window.tab_bar_synced is True
+    doc = window._center_tab_specs[0]["document"]
+    assert isinstance(doc, _Doc)
+    assert doc.selected_nickname == "Li01"
+    assert doc.editor_text == "editor text"


### PR DESCRIPTION
Superseded by a rebased PR created from the current `master` head.

Original body:

Closes #40

This preserves the view state when switching system tabs.

Changes:
- preserve restored 3D camera state during deferred scene refresh
- keep restored 2D tabs on their saved zoom/pan instead of syncing back from the 3D camera
- add regression coverage for both restore paths

Validation:
- `pytest tests/test_system_tab_document_runtime.py tests/test_system_document_runtime.py tests/test_system_tab_runtime.py --basetemp C:\Users\steve\Github\FLAtlas\.pytest_tmp3`