### PR TITLE
Fix #40 preserve system tab zoom state

### DIFF
--- a/fl_editor/system_document_runtime.py
+++ b/fl_editor/system_document_runtime.py
@@ -267,7 +267,9 @@ def _apply_system_document_data(
             if callable(queue_top_view_icons):
                 queue_top_view_icons(getattr(window, "_objects", []) or [])
             if should_refresh_3d:
-                window._refresh_3d_scene()
+                # Preserve the restored per-tab camera so deferred scene rebuilds
+                # do not snap the user back to the default system framing.
+                window._refresh_3d_scene(preserve_camera=True)
             if should_populate_quick_options:
                 window._populate_quick_editor_options(window._primary_game_path())
         finally:

--- a/fl_editor/system_tab_document_runtime.py
+++ b/fl_editor/system_tab_document_runtime.py
@@ -193,7 +193,12 @@ def restore_system_tab_state(window: Any, key: str | None = None) -> None:
     window.view3d_switch.blockSignals(True)
     window.view3d_switch.setChecked(use_3d)
     window.view3d_switch.blockSignals(False)
-    window._toggle_3d_view(use_3d)
+    if use_3d:
+        window._toggle_3d_view(True)
+    else:
+        center_set_current_widget = getattr(window, "_center_set_current_widget", None)
+        if callable(center_set_current_widget):
+            center_set_current_widget(getattr(window, "view", None), str(getattr(window, "_center_current_tab_key", "") or "").strip())
     cam_state = getattr(doc, "camera_state", None)
     if use_3d and isinstance(cam_state, dict) and hasattr(window.view3d, "set_camera_state"):
         try:


### PR DESCRIPTION
Closes #40

Preserves the saved system view when switching tabs.

- keep restored 3D camera state during deferred scene refresh
- keep restored 2D tabs on their saved zoom/pan instead of syncing back from the 3D camera