### PR TITLE
Add object previews to creation dialogs

### DIFF
--- a/fl_editor/dialogs.py
+++ b/fl_editor/dialogs.py
@@ -889,7 +889,7 @@ class BaseCreationDialog(QDialog):
     ):
         super().__init__(parent)
         self.setWindowTitle(tr("dlg.base_create"))
-        self.setMinimumSize(980, 760)
+        self.setMinimumSize(1280, 760)
         self._preview_builder = preview_builder
         self._preview_widget: QWidget | None = None
         self._preview_refresh_timer = QTimer(self)
@@ -1010,8 +1010,15 @@ class BaseCreationDialog(QDialog):
         layout = QFormLayout(content)
         self._main_form_layout = layout
         scroll.setWidget(content)
-        outer = QVBoxLayout(self)
-        outer.addWidget(scroll)
+        outer = QHBoxLayout(self)
+        outer.addWidget(scroll, 1)
+
+        preview_sidebar = QWidget(self)
+        preview_sidebar.setMinimumWidth(440)
+        preview_sidebar.setSizePolicy(QSizePolicy.Preferred, QSizePolicy.Expanding)
+        preview_sidebar_layout = QVBoxLayout(preview_sidebar)
+        preview_sidebar_layout.setContentsMargins(0, 0, 0, 0)
+        outer.addWidget(preview_sidebar, 0)
 
         sys_upper = system_nick.upper() if system_nick else ""
         num_str = f"{next_base_num:02d}"
@@ -1029,13 +1036,6 @@ class BaseCreationDialog(QDialog):
         self.ids_name_edit = QLineEdit()
         self.ids_name_edit.setPlaceholderText("Name")
         gl_base.addRow("Name:", self.ids_name_edit)
-
-        self.ids_info_preview = QTextEdit()
-        self.ids_info_preview.setReadOnly(True)
-        self.ids_info_preview.setMinimumHeight(130)
-        self.ids_info_preview.setLineWrapMode(QTextEdit.WidgetWidth)
-        self.ids_info_preview.setPlainText(self._xml_to_plain_preview(self._ids_info_template_xml))
-        gl_base.addRow("ids_info (Template Li01_03_Base):", self.ids_info_preview)
 
         layout.addRow(grp_base)
 
@@ -1110,23 +1110,32 @@ class BaseCreationDialog(QDialog):
         costume_layout.addRow("Body:", self.body_cb)
         gl_obj.addRow(costume_grp)
 
-        preview_group = QGroupBox("3D Preview", grp_obj)
+        preview_group = QGroupBox("3D Preview", preview_sidebar)
+        preview_group.setSizePolicy(QSizePolicy.Preferred, QSizePolicy.Expanding)
         preview_layout = QVBoxLayout(preview_group)
         self._preview_status_lbl = QLabel("Preview wird vorbereitet...", preview_group)
         self._preview_status_lbl.setWordWrap(True)
         preview_layout.addWidget(self._preview_status_lbl)
         self._preview_host = QWidget(preview_group)
+        self._preview_host.setMinimumSize(380, 520)
+        self._preview_host.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
         self._preview_host_layout = QVBoxLayout(self._preview_host)
         self._preview_host_layout.setContentsMargins(0, 0, 0, 0)
         preview_layout.addWidget(self._preview_host, 1)
-        gl_obj.addRow(preview_group)
+        preview_help_lbl = QLabel(
+            "Die Vorschau zeigt den aktuell gewahlten Archetype aus dem Space-Object-Bereich.",
+            preview_group,
+        )
+        preview_help_lbl.setWordWrap(True)
+        preview_help_lbl.setStyleSheet("color: palette(mid);")
+        preview_layout.addWidget(preview_help_lbl)
+        preview_sidebar_layout.addWidget(preview_group, 1)
 
         layout.addRow(grp_obj)
         self.arch_cb.currentTextChanged.connect(self._on_archetype_changed)
         self.arch_cb.currentTextChanged.connect(self._queue_preview_refresh)
         self.loadout_cb.currentTextChanged.connect(self._queue_preview_refresh)
         self._on_archetype_changed(self.arch_cb.currentText())
-        self._refresh_preview()
 
         # --- Rooms ---
         grp_rooms = QGroupBox(tr("dlg.grp_rooms"))
@@ -1222,6 +1231,7 @@ class BaseCreationDialog(QDialog):
         btns.accepted.connect(self.accept)
         btns.rejected.connect(self.reject)
         layout.addRow(btns)
+        self._refresh_preview()
 
     def _on_archetype_changed(self, archetype: str):
         arch_key = str(archetype or "").strip().lower()
@@ -1240,6 +1250,8 @@ class BaseCreationDialog(QDialog):
         timer.start()
 
     def _refresh_preview(self, *_args) -> None:
+        if not hasattr(self, "room_table"):
+            return
         previous_camera_state = None
         if self._preview_widget is not None:
             getter = getattr(self._preview_widget, "get_preview_camera_state", None)
@@ -2454,6 +2466,7 @@ class ObjectCreationDialog(QDialog):
     ):
         super().__init__(parent)
         self.setWindowTitle(tr("dlg.object_create"))
+        self.setMinimumSize(1080, 720)
         self._preview_builder = preview_builder
         self._preview_widget: QWidget | None = None
         self._preview_refresh_timer = QTimer(self)
@@ -2463,6 +2476,7 @@ class ObjectCreationDialog(QDialog):
 
         outer = QHBoxLayout(self)
         form_container = QWidget(self)
+        form_container.setSizePolicy(QSizePolicy.Preferred, QSizePolicy.Expanding)
         layout = QFormLayout(form_container)
         outer.addWidget(form_container, 0)
 
@@ -2499,15 +2513,21 @@ class ObjectCreationDialog(QDialog):
         layout.addRow(btns)
 
         preview_group = QGroupBox("3D Preview", self)
+        preview_group.setMinimumWidth(520)
+        preview_group.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
         preview_layout = QVBoxLayout(preview_group)
         self._preview_status_lbl = QLabel("Preview wird vorbereitet...", preview_group)
         self._preview_status_lbl.setWordWrap(True)
         preview_layout.addWidget(self._preview_status_lbl)
         self._preview_host = QWidget(preview_group)
+        self._preview_host.setMinimumSize(480, 560)
+        self._preview_host.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
         self._preview_host_layout = QVBoxLayout(self._preview_host)
         self._preview_host_layout.setContentsMargins(0, 0, 0, 0)
         preview_layout.addWidget(self._preview_host, 1)
         outer.addWidget(preview_group, 1)
+        outer.setStretch(0, 0)
+        outer.setStretch(1, 1)
 
         self.arch_cb.currentTextChanged.connect(self._queue_preview_refresh)
         self.loadout_cb.currentTextChanged.connect(self._queue_preview_refresh)
@@ -2576,6 +2596,7 @@ class CategoryObjectDialog(QDialog):
     ):
         super().__init__(parent)
         self.setWindowTitle(title)
+        self.setMinimumSize(1080, 720)
         self._preview_builder = preview_builder
         self._preview_widget: QWidget | None = None
         self._preview_refresh_timer = QTimer(self)
@@ -2585,6 +2606,7 @@ class CategoryObjectDialog(QDialog):
 
         outer = QHBoxLayout(self)
         form_container = QWidget(self)
+        form_container.setSizePolicy(QSizePolicy.Preferred, QSizePolicy.Expanding)
         layout = QFormLayout(form_container)
         outer.addWidget(form_container, 0)
 
@@ -2624,15 +2646,21 @@ class CategoryObjectDialog(QDialog):
         layout.addRow(btns)
 
         preview_group = QGroupBox("3D Preview", self)
+        preview_group.setMinimumWidth(520)
+        preview_group.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
         preview_layout = QVBoxLayout(preview_group)
         self._preview_status_lbl = QLabel("Preview wird vorbereitet...", preview_group)
         self._preview_status_lbl.setWordWrap(True)
         preview_layout.addWidget(self._preview_status_lbl)
         self._preview_host = QWidget(preview_group)
+        self._preview_host.setMinimumSize(480, 560)
+        self._preview_host.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
         self._preview_host_layout = QVBoxLayout(self._preview_host)
         self._preview_host_layout.setContentsMargins(0, 0, 0, 0)
         preview_layout.addWidget(self._preview_host, 1)
         outer.addWidget(preview_group, 1)
+        outer.setStretch(0, 0)
+        outer.setStretch(1, 1)
 
         self.arch_cb.currentTextChanged.connect(self._queue_preview_refresh)
         self.loadout_cb.currentTextChanged.connect(self._queue_preview_refresh)

--- a/fl_editor/dialogs.py
+++ b/fl_editor/dialogs.py
@@ -885,10 +885,17 @@ class BaseCreationDialog(QDialog):
         market_base_prices: dict[str, int] | None = None,
         market_shipdealer_enabled: bool = True,
         default_faction: str = "",
+        preview_builder: Callable[[dict[str, object], QWidget], QWidget | None] | None = None,
     ):
         super().__init__(parent)
         self.setWindowTitle(tr("dlg.base_create"))
         self.setMinimumSize(980, 760)
+        self._preview_builder = preview_builder
+        self._preview_widget: QWidget | None = None
+        self._preview_refresh_timer = QTimer(self)
+        self._preview_refresh_timer.setSingleShot(True)
+        self._preview_refresh_timer.setInterval(180)
+        self._preview_refresh_timer.timeout.connect(self._refresh_preview)
         self._updating_rooms = False
         self._ids_info_template_xml = str(ids_info_template_xml or "").strip()
         self._default_loadouts_by_archetype = {
@@ -1103,9 +1110,23 @@ class BaseCreationDialog(QDialog):
         costume_layout.addRow("Body:", self.body_cb)
         gl_obj.addRow(costume_grp)
 
+        preview_group = QGroupBox("3D Preview", grp_obj)
+        preview_layout = QVBoxLayout(preview_group)
+        self._preview_status_lbl = QLabel("Preview wird vorbereitet...", preview_group)
+        self._preview_status_lbl.setWordWrap(True)
+        preview_layout.addWidget(self._preview_status_lbl)
+        self._preview_host = QWidget(preview_group)
+        self._preview_host_layout = QVBoxLayout(self._preview_host)
+        self._preview_host_layout.setContentsMargins(0, 0, 0, 0)
+        preview_layout.addWidget(self._preview_host, 1)
+        gl_obj.addRow(preview_group)
+
         layout.addRow(grp_obj)
         self.arch_cb.currentTextChanged.connect(self._on_archetype_changed)
+        self.arch_cb.currentTextChanged.connect(self._queue_preview_refresh)
+        self.loadout_cb.currentTextChanged.connect(self._queue_preview_refresh)
         self._on_archetype_changed(self.arch_cb.currentText())
+        self._refresh_preview()
 
         # --- Rooms ---
         grp_rooms = QGroupBox(tr("dlg.grp_rooms"))
@@ -1210,6 +1231,42 @@ class BaseCreationDialog(QDialog):
         if not default_loadout:
             return
         self.loadout_cb.setCurrentText(default_loadout)
+
+    def _queue_preview_refresh(self, *_args) -> None:
+        timer = getattr(self, "_preview_refresh_timer", None)
+        if timer is None:
+            self._refresh_preview()
+            return
+        timer.start()
+
+    def _refresh_preview(self, *_args) -> None:
+        previous_camera_state = None
+        if self._preview_widget is not None:
+            getter = getattr(self._preview_widget, "get_preview_camera_state", None)
+            if callable(getter):
+                try:
+                    previous_camera_state = getter()
+                except Exception:
+                    previous_camera_state = None
+            self._preview_host_layout.removeWidget(self._preview_widget)
+            self._preview_widget.deleteLater()
+            self._preview_widget = None
+        if not callable(self._preview_builder):
+            self._preview_status_lbl.setText("Keine Preview verfugbar.")
+            return
+        preview = self._preview_builder(self.payload(), self._preview_host)
+        if preview is None:
+            self._preview_status_lbl.setText("Fur dieses Objekt ist aktuell keine 3D-Preview verfugbar.")
+            return
+        self._preview_widget = preview
+        self._preview_host_layout.addWidget(preview, 1)
+        setter = getattr(preview, "set_preview_camera_state", None)
+        if previous_camera_state is not None and callable(setter):
+            try:
+                setter(previous_camera_state)
+            except Exception:
+                pass
+        self._preview_status_lbl.setText("Die Vorschau folgt dem aktuell gewahlten Archetype.")
 
     def payload(self) -> dict:
         room_states = collect_room_states(
@@ -2393,10 +2450,21 @@ class ObjectCreationDialog(QDialog):
         archetypes: list[str],
         loadouts: list[str],
         factions: list[str],
+        preview_builder: Callable[[dict[str, object], QWidget], QWidget | None] | None = None,
     ):
         super().__init__(parent)
         self.setWindowTitle(tr("dlg.object_create"))
-        layout = QFormLayout(self)
+        self._preview_builder = preview_builder
+        self._preview_widget: QWidget | None = None
+        self._preview_refresh_timer = QTimer(self)
+        self._preview_refresh_timer.setSingleShot(True)
+        self._preview_refresh_timer.setInterval(180)
+        self._preview_refresh_timer.timeout.connect(self._refresh_preview)
+
+        outer = QHBoxLayout(self)
+        form_container = QWidget(self)
+        layout = QFormLayout(form_container)
+        outer.addWidget(form_container, 0)
 
         self.nick_edit = QLineEdit()
         layout.addRow("Nickname:", self.nick_edit)
@@ -2430,6 +2498,57 @@ class ObjectCreationDialog(QDialog):
         btns.rejected.connect(self.reject)
         layout.addRow(btns)
 
+        preview_group = QGroupBox("3D Preview", self)
+        preview_layout = QVBoxLayout(preview_group)
+        self._preview_status_lbl = QLabel("Preview wird vorbereitet...", preview_group)
+        self._preview_status_lbl.setWordWrap(True)
+        preview_layout.addWidget(self._preview_status_lbl)
+        self._preview_host = QWidget(preview_group)
+        self._preview_host_layout = QVBoxLayout(self._preview_host)
+        self._preview_host_layout.setContentsMargins(0, 0, 0, 0)
+        preview_layout.addWidget(self._preview_host, 1)
+        outer.addWidget(preview_group, 1)
+
+        self.arch_cb.currentTextChanged.connect(self._queue_preview_refresh)
+        self.loadout_cb.currentTextChanged.connect(self._queue_preview_refresh)
+        self._refresh_preview()
+
+    def _queue_preview_refresh(self, *_args) -> None:
+        timer = getattr(self, "_preview_refresh_timer", None)
+        if timer is None:
+            self._refresh_preview()
+            return
+        timer.start()
+
+    def _refresh_preview(self, *_args) -> None:
+        previous_camera_state = None
+        if self._preview_widget is not None:
+            getter = getattr(self._preview_widget, "get_preview_camera_state", None)
+            if callable(getter):
+                try:
+                    previous_camera_state = getter()
+                except Exception:
+                    previous_camera_state = None
+            self._preview_host_layout.removeWidget(self._preview_widget)
+            self._preview_widget.deleteLater()
+            self._preview_widget = None
+        if not callable(self._preview_builder):
+            self._preview_status_lbl.setText("Keine Preview verfugbar.")
+            return
+        preview = self._preview_builder(self.payload(), self._preview_host)
+        if preview is None:
+            self._preview_status_lbl.setText("Fur dieses Objekt ist aktuell keine 3D-Preview verfugbar.")
+            return
+        self._preview_widget = preview
+        self._preview_host_layout.addWidget(preview, 1)
+        setter = getattr(preview, "set_preview_camera_state", None)
+        if previous_camera_state is not None and callable(setter):
+            try:
+                setter(previous_camera_state)
+            except Exception:
+                pass
+        self._preview_status_lbl.setText("Die Vorschau folgt dem aktuell gewahlten Archetype.")
+
     def payload(self) -> dict:
         return build_object_creation_payload(
             nickname=self.nick_edit.text(),
@@ -2453,10 +2572,21 @@ class CategoryObjectDialog(QDialog):
         loadouts: list[str],
         factions: list[str] = None,
         show_reputation: bool = False,
+        preview_builder: Callable[[dict[str, object], QWidget], QWidget | None] | None = None,
     ):
         super().__init__(parent)
         self.setWindowTitle(title)
-        layout = QFormLayout(self)
+        self._preview_builder = preview_builder
+        self._preview_widget: QWidget | None = None
+        self._preview_refresh_timer = QTimer(self)
+        self._preview_refresh_timer.setSingleShot(True)
+        self._preview_refresh_timer.setInterval(180)
+        self._preview_refresh_timer.timeout.connect(self._refresh_preview)
+
+        outer = QHBoxLayout(self)
+        form_container = QWidget(self)
+        layout = QFormLayout(form_container)
+        outer.addWidget(form_container, 0)
 
         self.arch_cb = QComboBox()
         self.arch_cb.setEditable(True)
@@ -2492,6 +2622,57 @@ class CategoryObjectDialog(QDialog):
         btns.accepted.connect(self.accept)
         btns.rejected.connect(self.reject)
         layout.addRow(btns)
+
+        preview_group = QGroupBox("3D Preview", self)
+        preview_layout = QVBoxLayout(preview_group)
+        self._preview_status_lbl = QLabel("Preview wird vorbereitet...", preview_group)
+        self._preview_status_lbl.setWordWrap(True)
+        preview_layout.addWidget(self._preview_status_lbl)
+        self._preview_host = QWidget(preview_group)
+        self._preview_host_layout = QVBoxLayout(self._preview_host)
+        self._preview_host_layout.setContentsMargins(0, 0, 0, 0)
+        preview_layout.addWidget(self._preview_host, 1)
+        outer.addWidget(preview_group, 1)
+
+        self.arch_cb.currentTextChanged.connect(self._queue_preview_refresh)
+        self.loadout_cb.currentTextChanged.connect(self._queue_preview_refresh)
+        self._refresh_preview()
+
+    def _queue_preview_refresh(self, *_args) -> None:
+        timer = getattr(self, "_preview_refresh_timer", None)
+        if timer is None:
+            self._refresh_preview()
+            return
+        timer.start()
+
+    def _refresh_preview(self, *_args) -> None:
+        previous_camera_state = None
+        if self._preview_widget is not None:
+            getter = getattr(self._preview_widget, "get_preview_camera_state", None)
+            if callable(getter):
+                try:
+                    previous_camera_state = getter()
+                except Exception:
+                    previous_camera_state = None
+            self._preview_host_layout.removeWidget(self._preview_widget)
+            self._preview_widget.deleteLater()
+            self._preview_widget = None
+        if not callable(self._preview_builder):
+            self._preview_status_lbl.setText("Keine Preview verfugbar.")
+            return
+        preview = self._preview_builder(self.payload(), self._preview_host)
+        if preview is None:
+            self._preview_status_lbl.setText("Fur dieses Objekt ist aktuell keine 3D-Preview verfugbar.")
+            return
+        self._preview_widget = preview
+        self._preview_host_layout.addWidget(preview, 1)
+        setter = getattr(preview, "set_preview_camera_state", None)
+        if previous_camera_state is not None and callable(setter):
+            try:
+                setter(previous_camera_state)
+            except Exception:
+                pass
+        self._preview_status_lbl.setText("Die Vorschau folgt dem aktuell gewahlten Archetype.")
 
     def payload(self) -> dict:
         return build_category_object_payload(

--- a/fl_editor/main_window.py
+++ b/fl_editor/main_window.py
@@ -24798,7 +24798,17 @@ class MainWindow(QMainWindow):
         if not loadouts:
             loadouts = list(raw_loadouts)
         factions = [self.faction_cb.itemText(i) for i in range(self.faction_cb.count()) if self.faction_cb.itemText(i)]
-        dlg = ObjectCreationDialog(self, archetypes, loadouts, factions)
+        dlg = ObjectCreationDialog(
+            self,
+            archetypes,
+            loadouts,
+            factions,
+            preview_builder=lambda payload, parent: self._create_archetype_preview_widget(
+                payload,
+                parent,
+                title="Object Preview",
+            ),
+        )
         dlg.nick_edit.setText(
             self._suggest_system_scoped_name("object", [o.nickname for o in self._objects])
         )
@@ -25220,7 +25230,19 @@ class MainWindow(QMainWindow):
             return
         factions = list(self._cached_faction_labels) if self._cached_faction_labels else list(self._cached_factions)
         arches, loads = self._collect_category_templates(arche_keywords, loadout_keywords, strict=strict_arche)
-        dlg = CategoryObjectDialog(self, title=title, archetypes=arches, loadouts=loads, factions=factions, show_reputation=show_reputation)
+        dlg = CategoryObjectDialog(
+            self,
+            title=title,
+            archetypes=arches,
+            loadouts=loads,
+            factions=factions,
+            show_reputation=show_reputation,
+            preview_builder=lambda payload, parent: self._create_archetype_preview_widget(
+                payload,
+                parent,
+                title=f"{title} Preview",
+            ),
+        )
         if dlg.exec() != QDialog.Accepted:
             return
         payload = dlg.payload()
@@ -28204,6 +28226,11 @@ class MainWindow(QMainWindow):
             market_display_names=display_names,
             market_base_prices=base_prices,
             market_shipdealer_enabled=shipdealer_enabled,
+            preview_builder=lambda payload, parent: self._create_archetype_preview_widget(
+                payload,
+                parent,
+                title="Base Preview",
+            ),
         )
         dlg.setWindowTitle(f"{tr('edit.base')}: {base_nick}")
         dlg.base_nick_edit.setText(base_nick)
@@ -30956,6 +30983,54 @@ class MainWindow(QMainWindow):
         widget.setMinimumSize(0, 0)
         return widget
 
+    def _create_archetype_preview_widget(
+        self,
+        payload: dict[str, object],
+        parent: QWidget,
+        *,
+        title: str = "3D Preview",
+    ) -> QWidget | None:
+        archetype = str(payload.get("archetype", "") or "").strip()
+        if not archetype:
+            return None
+        game_path = self._primary_game_path()
+        if not game_path:
+            return None
+        model_path, da_arch = self._resolve_model_for_archetype(archetype, game_path)
+        if not da_arch or model_path is None:
+            return None
+        preview_resolution = resolve_preview_mesh_candidate(model_path)
+        preview_mesh = preview_resolution.preview_path
+        arch_key = archetype.lower()
+        if model_path.suffix.lower() == ".sph" or "sun" in arch_key or "planet" in arch_key:
+            primitive = "sphere"
+        elif any(token in arch_key for token in ("jumpgate", "jump_gate", "nomad_gate")):
+            primitive = "jumpgate"
+        else:
+            primitive = "cube"
+        native_model = None
+        native_scene_data = None
+        if preview_mesh is None and preview_resolution.is_freelancer_native:
+            try:
+                native_model = load_native_freelancer_model(model_path)
+                native_scene_result = load_native_scene_data(model_path)
+                native_scene_data = native_scene_result.scene_data if native_scene_result is not None else None
+            except Exception:
+                native_model = None
+                native_scene_data = None
+        widget = MeshPreviewDialog(
+            parent,
+            preview_mesh,
+            title,
+            primitive=primitive if preview_mesh is None else None,
+            native_model=native_model,
+            material_library_paths=self._resolve_material_library_paths(archetype, game_path),
+            scene_data=native_scene_data,
+        )
+        widget.setWindowFlags(Qt.Widget)
+        widget.setMinimumSize(0, 0)
+        return widget
+
     def _open_ring_dialog_for_object(self, obj: SolarObject) -> None:
         self._pending_ring_attach = None
         game_path = self._primary_game_path()
@@ -33101,6 +33176,11 @@ class MainWindow(QMainWindow):
             ids_info_template_xml=li01_03_xml,
             default_loadouts_by_archetype=default_loadouts_by_archetype,
             default_faction=self._current_system_local_faction_ui_label(),
+            preview_builder=lambda payload, parent: self._create_archetype_preview_widget(
+                payload,
+                parent,
+                title="Base Preview",
+            ),
         )
         if dlg.exec() != QDialog.Accepted:
             return

--- a/fl_editor/main_window.py
+++ b/fl_editor/main_window.py
@@ -28239,7 +28239,6 @@ class MainWindow(QMainWindow):
         dlg.obj_nick_edit.setReadOnly(True)
         dlg.ids_name_edit.setText(str(current_name_text or "").strip())
         dlg._ids_info_template_xml = str(current_infocard_xml or "").strip()
-        dlg.ids_info_preview.setPlainText(dlg._xml_to_plain_preview(dlg._ids_info_template_xml))
 
         dlg.arch_cb.setCurrentText(self._entry_get_value(obj_entries, "archetype").strip())
         dlg.loadout_cb.setCurrentText(self._entry_get_value(obj_entries, "loadout").strip())

--- a/tests/test_dialog_smoke.py
+++ b/tests/test_dialog_smoke.py
@@ -62,6 +62,58 @@ def test_base_creation_dialog_builds_default_room_state(qapp):
     assert dialog.faction_cb.completer().filterMode() == Qt.MatchContains
 
 
+def test_base_creation_dialog_preserves_preview_camera_state_on_refresh(qapp):
+    restored_states: list[dict[str, object]] = []
+
+    class _PreviewWidget(QWidget):
+        def __init__(self):
+            super().__init__()
+            self._state = {
+                "center": (1.0, 2.0, 3.0),
+                "position": (4.0, 5.0, 6.0),
+                "distance": 7.0,
+                "yaw_deg": 8.0,
+                "pitch_deg": 9.0,
+                "zoom_factor": 1.25,
+            }
+
+        def get_preview_camera_state(self):
+            return dict(self._state)
+
+        def set_preview_camera_state(self, state):
+            restored_states.append(dict(state))
+
+    def _preview_builder(_payload, _parent):
+        return _PreviewWidget()
+
+    dialog = BaseCreationDialog(
+        None,
+        system_nick="li01",
+        archetypes=["space_police01", "space_police02"],
+        loadouts=["police_loadout"],
+        factions=["li_n_grp - Liberty Navy"],
+        default_faction="li_n_grp - Liberty Navy",
+        existing_bases=["li01_02_base"],
+        next_base_num=1,
+        pilots=["pilot_solar_easiest"],
+        voices=["mc_leg_m01"],
+        heads=["trent_head"],
+        bodies=["trent_body"],
+        template_room_details={},
+        template_room_npcs={},
+        template_virtual_targets={},
+        ids_info_template_xml="<RDL><TEXT><PARA>Base Info</PARA></TEXT></RDL>",
+        preview_builder=_preview_builder,
+    )
+
+    dialog.arch_cb.setCurrentText("space_police02")
+    dialog._preview_refresh_timer.stop()
+    dialog._refresh_preview()
+
+    assert restored_states
+    assert restored_states[-1]["position"] == (4.0, 5.0, 6.0)
+
+
 def test_base_creation_dialog_applies_template_room_state(qapp):
     dialog = BaseCreationDialog(
         None,
@@ -689,6 +741,29 @@ def test_object_creation_dialog_builds_payload_from_inputs(qapp):
     assert payload["faction"] == "li_n_grp"
 
 
+def test_object_creation_dialog_refreshes_preview_for_selected_archetype(qapp):
+    previews: list[dict[str, object]] = []
+
+    def _preview_builder(payload, _parent):
+        previews.append(dict(payload))
+        return QWidget()
+
+    dialog = ObjectCreationDialog(
+        None,
+        archetypes=["station_a", "station_b"],
+        loadouts=["loadout_a"],
+        factions=["li_n_grp"],
+        preview_builder=_preview_builder,
+    )
+
+    dialog.arch_cb.setCurrentText("station_b")
+    dialog._preview_refresh_timer.stop()
+    dialog._refresh_preview()
+
+    assert previews
+    assert previews[-1]["archetype"] == "station_b"
+
+
 def test_object_ring_dialog_builds_payload_and_preview_updates(qapp):
     previews: list[dict[str, object]] = []
 
@@ -820,6 +895,31 @@ def test_category_object_dialog_builds_payload_with_optional_rep_fields(qapp):
     assert payload["ids_name_text"] == "Wreck A"
     assert payload["faction"] == "li_n_grp"
     assert payload["rep"] == "rep_a"
+
+
+def test_category_object_dialog_refreshes_preview_for_selected_archetype(qapp):
+    previews: list[dict[str, object]] = []
+
+    def _preview_builder(payload, _parent):
+        previews.append(dict(payload))
+        return QWidget()
+
+    dialog = CategoryObjectDialog(
+        None,
+        title="Create Wreck",
+        archetypes=["wreck_a", "wreck_b"],
+        loadouts=["loadout_a"],
+        factions=["li_n_grp"],
+        show_reputation=True,
+        preview_builder=_preview_builder,
+    )
+
+    dialog.arch_cb.setCurrentText("wreck_b")
+    dialog._preview_refresh_timer.stop()
+    dialog._refresh_preview()
+
+    assert previews
+    assert previews[-1]["archetype"] == "wreck_b"
 
 
 def test_buoy_dialog_updates_pattern_and_payload(qapp):


### PR DESCRIPTION
## Summary
- add embedded 3D archetype previews to object and category creation dialogs
- move the base creation preview into a roomy right sidebar and remove the ids_info preview block
- preserve preview camera state across refreshes and avoid early base dialog preview initialization crashes

Closes #23