### PR TITLE
Add INI editor section context actions

### DIFF
--- a/fl_editor/ini_editor_page.py
+++ b/fl_editor/ini_editor_page.py
@@ -441,6 +441,8 @@ def build_ini_editor_page(window, *, tr, code_editor_factory, highlighter_factor
     window.ini_sections_list = QListWidget()
     window.ini_sections_list.itemActivated.connect(window._ini_editor_jump_to_section)
     window.ini_sections_list.itemClicked.connect(window._ini_editor_jump_to_section)
+    window.ini_sections_list.setContextMenuPolicy(Qt.CustomContextMenu)
+    window.ini_sections_list.customContextMenuRequested.connect(window._ini_editor_show_sections_context_menu)
     split.addWidget(window.ini_sections_list)
     split.setSizes([280, 900, 260])
 

--- a/fl_editor/main_window.py
+++ b/fl_editor/main_window.py
@@ -13543,6 +13543,69 @@ class MainWindow(QMainWindow):
             item.setData(Qt.UserRole, int(block_number))
             self.ini_sections_list.addItem(item)
 
+    def _ini_editor_section_block_numbers(self) -> list[int]:
+        return [int(block_number) for _title, block_number in parse_ini_sections(self.ini_code_edit.toPlainText())]
+
+    def _ini_editor_section_line_range(self, block_number: int) -> tuple[int, int] | None:
+        block_numbers = self._ini_editor_section_block_numbers()
+        if not block_numbers:
+            return None
+        try:
+            start_index = block_numbers.index(int(block_number))
+        except ValueError:
+            return None
+        start_block = int(block_numbers[start_index])
+        end_block = int(block_numbers[start_index + 1]) if start_index + 1 < len(block_numbers) else int(self.ini_code_edit.blockCount())
+        return start_block, end_block
+
+    def _ini_editor_section_text_by_block(self, block_number: int) -> str:
+        line_range = self._ini_editor_section_line_range(block_number)
+        if line_range is None:
+            return ""
+        start_block, end_block = line_range
+        lines = self.ini_code_edit.toPlainText().splitlines()
+        return "\n".join(lines[start_block:end_block]).strip()
+
+    def _ini_editor_current_section_block_number(self, cursor: QTextCursor | None = None) -> int | None:
+        current_cursor = cursor if cursor is not None else self.ini_code_edit.textCursor()
+        line_no = int(current_cursor.block().blockNumber())
+        section_blocks = self._ini_editor_section_block_numbers()
+        current_block: int | None = None
+        for block_number in section_blocks:
+            if int(block_number) > line_no:
+                break
+            current_block = int(block_number)
+        return current_block
+
+    def _ini_editor_select_section_by_block(self, block_number: int) -> bool:
+        line_range = self._ini_editor_section_line_range(block_number)
+        if line_range is None:
+            return False
+        start_block, end_block = line_range
+        start_qblock = self.ini_code_edit.document().findBlockByNumber(start_block)
+        if not start_qblock.isValid():
+            return False
+        if end_block > start_block:
+            end_qblock = self.ini_code_edit.document().findBlockByNumber(end_block)
+            end_pos = int(end_qblock.position()) if end_qblock.isValid() else len(self.ini_code_edit.toPlainText())
+        else:
+            end_pos = int(start_qblock.position() + len(start_qblock.text()))
+        cursor = self.ini_code_edit.textCursor()
+        cursor.setPosition(int(start_qblock.position()))
+        cursor.setPosition(max(int(start_qblock.position()), int(end_pos)), QTextCursor.KeepAnchor)
+        self.ini_code_edit.setTextCursor(cursor)
+        self.ini_code_edit.centerCursor()
+        return True
+
+    def _ini_editor_copy_section_by_block(self, block_number: int) -> bool:
+        section_text = self._ini_editor_section_text_by_block(block_number)
+        if not section_text:
+            return False
+        QApplication.clipboard().setText(section_text)
+        self._clipboard_collector_add_items([section_text])
+        self.statusBar().showMessage(self._ini_explorer_collector_action_text("status_added").format(count=1))
+        return True
+
     def _ini_editor_jump_to_section(self, item):
         if item is None:
             return
@@ -13572,6 +13635,28 @@ class MainWindow(QMainWindow):
             self._ini_editor_jump_to_section(item)
             return True
         return False
+
+    def _ini_editor_show_sections_context_menu(self, pos) -> None:
+        section_list = getattr(self, "ini_sections_list", None)
+        if section_list is None:
+            return
+        item = section_list.itemAt(pos)
+        if item is None:
+            return
+        menu = QMenu(self)
+        jump_action = menu.addAction("Jump to section")
+        copy_action = menu.addAction("Copy section")
+        action = menu.exec(section_list.viewport().mapToGlobal(pos))
+        if action is jump_action:
+            self.ini_sections_list.setCurrentItem(item)
+            self._ini_editor_jump_to_section(item)
+        elif action is copy_action:
+            try:
+                block_no = int(item.data(Qt.UserRole))
+            except Exception:
+                return
+            self.ini_sections_list.setCurrentItem(item)
+            self._ini_editor_copy_section_by_block(block_no)
 
     @staticmethod
     def _ini_editor_line_text_at_cursor(cursor: QTextCursor) -> tuple[int, str, int]:
@@ -16835,6 +16920,7 @@ class MainWindow(QMainWindow):
     def _ini_editor_show_line_history_menu(self, pos):
         cursor = self.ini_code_edit.cursorForPosition(pos)
         line_no, line_text, column = self._ini_editor_line_text_at_cursor(cursor)
+        section_block_no = self._ini_editor_current_section_block_number(cursor)
         history = self._ini_editor_load_line_history(self._ini_editor_current_file)
         current_lines = self.ini_code_edit.toPlainText().splitlines()
         normalized = self._ini_editor_normalize_line_history(history, current_lines, self._ini_editor_current_file)
@@ -16856,6 +16942,16 @@ class MainWindow(QMainWindow):
                 action.deleteLater()
         copy_action = menu.addAction(tr("ini.icon.copy"))
         copy_action.triggered.connect(self._ini_editor_copy_selection_to_collector)
+        if section_block_no is not None:
+            menu.addSeparator()
+            select_section_action = menu.addAction("Select section")
+            select_section_action.triggered.connect(
+                lambda checked=False, block_no=int(section_block_no): self._ini_editor_select_section_by_block(block_no)
+            )
+            copy_section_action = menu.addAction("Copy section")
+            copy_section_action.triggered.connect(
+                lambda checked=False, block_no=int(section_block_no): self._ini_editor_copy_section_by_block(block_no)
+            )
         selected_text = self._ini_editor_selected_text_for_search()
         if selected_text:
             menu.addSeparator()

--- a/fl_editor/main_window.py
+++ b/fl_editor/main_window.py
@@ -14481,34 +14481,6 @@ class MainWindow(QMainWindow):
         self.ini_code_edit.setTextCursor(cursor)
         self.ini_code_edit.centerCursor()
 
-    def _ini_editor_current_section_block_number(self) -> int | None:
-        current_item = self.ini_sections_list.currentItem() if hasattr(self, "ini_sections_list") else None
-        if current_item is not None:
-            try:
-                return int(current_item.data(Qt.UserRole))
-            except Exception:
-                pass
-        if not hasattr(self, "ini_code_edit"):
-            return None
-        try:
-            cursor_block = int(self.ini_code_edit.textCursor().blockNumber())
-        except Exception:
-            return None
-        best_match: int | None = None
-        for row_index in range(self.ini_sections_list.count()):
-            item = self.ini_sections_list.item(row_index)
-            if item is None:
-                continue
-            try:
-                block_no = int(item.data(Qt.UserRole))
-            except Exception:
-                continue
-            if block_no <= cursor_block:
-                best_match = block_no
-            else:
-                break
-        return best_match
-
     def _ini_editor_open_usage_result(self, usage: dict[str, object]):
         path = str(usage.get("path", "") or "").strip()
         if not path:

--- a/tests/test_main_window_smoke.py
+++ b/tests/test_main_window_smoke.py
@@ -995,6 +995,118 @@ def test_ini_editor_select_section_containing_jumps_to_match(main_window):
     assert main_window.ini_sections_list.currentItem().text() == "[Good]  nickname = commodity_gold"
 
 
+def test_ini_editor_select_section_by_block_selects_whole_section(main_window):
+    main_window._open_ini_editor_view()
+    main_window.ini_code_edit.setPlainText("[first]\na = 1\n\n[second]\nb = 2\nc = 3\n")
+
+    assert main_window._ini_editor_select_section_by_block(3) is True
+    assert main_window.ini_code_edit.textCursor().selectedText().replace("\u2029", "\n").strip() == "[second]\nb = 2\nc = 3"
+
+
+def test_ini_editor_sections_sidebar_context_menu_can_copy_section(main_window, monkeypatch):
+    main_window._open_ini_editor_view()
+    main_window.ini_code_edit.setPlainText("[first]\na = 1\n\n[second]\nb = 2\nc = 3\n")
+    main_window._ini_editor_refresh_sections()
+    copied: list[int] = []
+
+    class _FakeAction:
+        def __init__(self, text: str):
+            self._text = text
+
+        def text(self) -> str:
+            return self._text
+
+    class _FakeMenu:
+        def __init__(self, *_args, **_kwargs):
+            self._actions: list[_FakeAction] = []
+
+        def addAction(self, text: str):
+            action = _FakeAction(text)
+            self._actions.append(action)
+            return action
+
+        def addSeparator(self):
+            return None
+
+        def exec(self, *_args, **_kwargs):
+            return next(action for action in self._actions if action.text() == "Copy section")
+
+    monkeypatch.setattr("fl_editor.main_window.QMenu", _FakeMenu)
+    monkeypatch.setattr(main_window, "_ini_editor_copy_section_by_block", lambda block_no: copied.append(int(block_no)) or True)
+
+    item = main_window.ini_sections_list.item(1)
+    rect = main_window.ini_sections_list.visualItemRect(item)
+    main_window._ini_editor_show_sections_context_menu(rect.center())
+
+    assert copied == [3]
+
+
+def test_ini_editor_context_menu_can_select_whole_section(main_window, monkeypatch):
+    main_window._open_ini_editor_view()
+    main_window._ini_editor_current_file = "C:/fake/test.ini"
+    main_window.ini_code_edit.setPlainText("[first]\na = 1\n\n[second]\nb = 2\nc = 3\n")
+    cursor = main_window.ini_code_edit.textCursor()
+    cursor.setPosition(main_window.ini_code_edit.toPlainText().index("b = 2"))
+    main_window.ini_code_edit.setTextCursor(cursor)
+    selected: list[int] = []
+
+    class _FakeSignal:
+        def __init__(self):
+            self._callbacks = []
+
+        def connect(self, callback):
+            self._callbacks.append(callback)
+
+        def fire(self):
+            for callback in list(self._callbacks):
+                callback()
+
+    class _FakeAction:
+        def __init__(self, text: str):
+            self._text = text
+            self.triggered = _FakeSignal()
+
+        def text(self) -> str:
+            return self._text
+
+        def deleteLater(self):
+            return None
+
+    class _FakeMenu:
+        def __init__(self):
+            self._actions: list[_FakeAction] = []
+
+        def addAction(self, text: str):
+            action = _FakeAction(text)
+            self._actions.append(action)
+            return action
+
+        def addSeparator(self):
+            return None
+
+        def actions(self):
+            return list(self._actions)
+
+        def removeAction(self, action):
+            self._actions = [entry for entry in self._actions if entry is not action]
+
+        def exec(self, *_args, **_kwargs):
+            action = next(entry for entry in self._actions if entry.text() == "Select section")
+            action.triggered.fire()
+            return action
+
+    fake_menu = _FakeMenu()
+    fake_menu.addAction("Copy")
+    monkeypatch.setattr(main_window.ini_code_edit, "createStandardContextMenu", lambda *_args, **_kwargs: fake_menu)
+    monkeypatch.setattr(main_window, "_ini_editor_load_line_history", lambda *_args, **_kwargs: {})
+    monkeypatch.setattr(main_window, "_ini_editor_select_section_by_block", lambda block_no: selected.append(int(block_no)) or True)
+
+    point = main_window.ini_code_edit.cursorRect(cursor).center()
+    main_window._ini_editor_show_line_history_menu(point)
+
+    assert selected == [3]
+
+
 def test_ini_editor_current_search_term_prefers_selection_and_word_under_cursor(main_window):
     from PySide6.QtGui import QTextCursor
 


### PR DESCRIPTION
## Summary
- add section-select and section-copy actions to the INI editor context menu
- add jump/copy actions to the right-hand section list context menu
- fix the section context menu crash caused by a duplicate helper override

Closes #46