### PR TITLE
Fix free cam strafe direction

### DIFF
--- a/fl_editor/view_3d.py
+++ b/fl_editor/view_3d.py
@@ -882,7 +882,10 @@ class System3DView(QWidget):
 
     def _right_vector(self) -> QVector3D:
         forward = self._forward_vector()
-        right = QVector3D(float(forward.z()), 0.0, float(-forward.x()))
+        # The system view uses a mirrored horizontal world orientation compared to
+        # a conventional FPS basis, so the free-cam strafe vector must be flipped
+        # to keep A = left and D = right from the user's perspective.
+        right = QVector3D(float(-forward.z()), 0.0, float(forward.x()))
         if right.lengthSquared() <= 1e-9:
             return QVector3D(1.0, 0.0, 0.0)
         return right.normalized()

--- a/tests/test_view_3d_widget_smoke.py
+++ b/tests/test_view_3d_widget_smoke.py
@@ -871,6 +871,31 @@ def test_system3dview_free_camera_moves_and_stops_immediately(qapp):
     assert stopped_pos == moved_pos
 
 
+def test_system3dview_free_camera_strafe_matches_a_d_labels(qapp):
+    view = System3DView()
+
+    if not QT3D_AVAILABLE:
+        assert view.layout() is not None
+        return
+
+    view.set_free_camera_active(True)
+    view._free_camera_pos = QVector3D(0.0, 0.0, 0.0)
+    view._free_camera_yaw = 0.0
+    view._free_camera_pitch = 0.0
+
+    view._free_camera_keys_down = {int(Qt.Key_D)}
+    view._on_free_camera_tick()
+    pos_after_d = QVector3D(view._free_camera_pos)
+
+    view._free_camera_pos = QVector3D(0.0, 0.0, 0.0)
+    view._free_camera_keys_down = {int(Qt.Key_A)}
+    view._on_free_camera_tick()
+    pos_after_a = QVector3D(view._free_camera_pos)
+
+    assert pos_after_d.x() < 0.0
+    assert pos_after_a.x() > 0.0
+
+
 def test_system3dview_native_detail_debug_state_tracks_multiple_geometries(qapp):
     view = System3DView()
 


### PR DESCRIPTION
## Summary
- fix the mirrored free-cam strafe vector in the 3D system view
- keep A moving left and D moving right in Free Cam mode
- add a regression test for the free-cam strafe mapping

Closes #52