### PR TITLE
Fix tradelane ring count on reposition

### DIFF
--- a/fl_editor/main_window.py
+++ b/fl_editor/main_window.py
@@ -27710,7 +27710,12 @@ class MainWindow(QMainWindow):
 
     def _generate_tradelane(self, sx: float, sz: float,
                             ex: float, ez: float,
-                            cfg: dict, system_nick: str):
+                            cfg: dict, system_nick: str,
+                            *,
+                            refresh_3d: bool = True,
+                            select_created: bool = True,
+                            push_undo: bool = True,
+                            rebuild_combo: bool = True):
         """Erzeugt alle Trade_Lane_Ring-Objekte zwischen Start und Ende."""
         count = cfg["ring_count"]
         start_num = cfg["start_num"]
@@ -27765,7 +27770,19 @@ class MainWindow(QMainWindow):
             elif i == count - 1 and cfg.get("space_name_end", "0") != "0":
                 entries.append(("tradelane_space_name", cfg["space_name_end"]))
 
-            self._add_object_from_entries(entries, "Object")
+            self._add_object_from_entries(
+                entries,
+                "Object",
+                refresh_3d=False,
+                select_created=bool(select_created and i == (count - 1)),
+                push_undo=push_undo,
+                rebuild_combo=False,
+            )
+
+        if rebuild_combo:
+            self._rebuild_object_combo()
+        if refresh_3d:
+            self._refresh_3d_scene()
 
         self.statusBar().showMessage(
             tr("status.tl_created_detail").format(
@@ -27917,28 +27934,7 @@ class MainWindow(QMainWindow):
         ) != QMessageBox.Ok:
             return
 
-        for ring in chain:
-            obj: SolarObject = ring["_obj"]
-            # Sektion aus _sections entfernen
-            obj_idx = None
-            try:
-                obj_idx = self._objects.index(obj)
-            except ValueError:
-                continue
-            count = 0
-            for i, (sec_name, entries) in enumerate(list(self._sections)):
-                if sec_name.lower() == "object":
-                    if count == obj_idx:
-                        self._sections.pop(i)
-                        break
-                    count += 1
-            self.view._scene.removeItem(obj)
-            if obj in self._objects:
-                self._objects.remove(obj)
-
-        self._rebuild_object_combo()
-        self._selected = None
-        self._clear_selection_ui()
+        self._remove_tradelane_chain_objects(chain)
         self._set_dirty(True)
         self._write_to_file(reload=False)
         self.statusBar().showMessage(
@@ -27947,6 +27943,31 @@ class MainWindow(QMainWindow):
             )
         )
         self._refresh_3d_scene()
+
+    def _remove_tradelane_chain_objects(self, chain: list[dict]) -> None:
+        had_selected = False
+        for ring in chain:
+            obj: SolarObject = ring["_obj"]
+            had_selected = had_selected or (self._selected is obj)
+            obj_idx = None
+            try:
+                obj_idx = self._objects.index(obj)
+            except ValueError:
+                continue
+            count = 0
+            for i, (sec_name, _entries) in enumerate(list(self._sections)):
+                if sec_name.lower() == "object":
+                    if count == obj_idx:
+                        self._sections.pop(i)
+                        break
+                    count += 1
+            self.view._scene.removeItem(obj)
+            if obj in self._objects:
+                self._objects.remove(obj)
+        self._rebuild_object_combo()
+        if had_selected:
+            self._selected = None
+            self._clear_selection_ui()
 
     def _reposition_tradelane_chain(self, chain: list[dict]):
         """Startet den Zwei-Klick-Modus zum Neusetzen von Start-/Endpunkt."""
@@ -27992,60 +28013,67 @@ class MainWindow(QMainWindow):
         sz = start_pos.y() / self._scale
         ex = end_pos.x() / self._scale
         ez = end_pos.y() / self._scale
-        count = len(chain)
-
         dx = ex - sx
         dz = ez - sz
+        new_distance = math.hypot(dx, dz)
 
-        # Neue Rotation berechnen
-        angle_rad = math.atan2(dx, dz)
-        angle_deg = math.degrees(angle_rad) + 180.0
-        if angle_deg > 180.0:
-            angle_deg -= 360.0
-        rotate_str = f"0, {angle_deg:.0f}, 0"
+        def _entry_value(obj: SolarObject, key: str) -> str:
+            key_l = str(key or "").strip().lower()
+            val = str(obj.data.get(key, "") or "").strip()
+            if val:
+                return val
+            for ek, ev in obj.data.get("_entries", []) or []:
+                if str(ek).strip().lower() == key_l:
+                    return str(ev).strip()
+            return ""
 
-        for i, ring in enumerate(chain):
-            obj: SolarObject = ring["_obj"]
-            t = i / max(count - 1, 1)
-            px = sx + dx * t
-            pz = sz + dz * t
-            new_pos = f"{px:.0f}, 0, {pz:.0f}"
+        old_sx, _old_sy, old_sz = parse_position(str(chain[0].get("pos", "0,0,0") or "0,0,0"))
+        old_ex, _old_ey, old_ez = parse_position(str(chain[-1].get("pos", "0,0,0") or "0,0,0"))
+        old_distance = math.hypot(old_ex - old_sx, old_ez - old_sz)
+        spacing = old_distance / max(len(chain) - 1, 1)
+        if spacing <= 1e-6:
+            spacing = 7500.0
+        count = max(2, round(new_distance / spacing) + 1)
 
-            # Einträge aktualisieren
-            entries = obj.data.get("_entries", [])
-            new_entries = []
-            for k, v in entries:
-                if k.lower() == "pos":
-                    new_entries.append((k, new_pos))
-                else:
-                    new_entries.append((k, v))
-            obj.data["_entries"] = new_entries
-            obj.data["pos"] = new_pos
-            rx, _ry, rz = self._get_object_rotate(obj)
-            self._set_object_rotate(obj, (rx, angle_deg, rz))
-            new_entries = list(obj.data.get("_entries", []))
+        first_obj: SolarObject = chain[0]["_obj"]
+        first_nick = str(chain[0].get("nickname", "") or "").strip()
+        match = re.search(r"^(.*)_Trade_Lane_Ring_(\d+)$", first_nick, flags=re.IGNORECASE)
+        system_nick = match.group(1) if match else (self._system_nickname_for_path(self._filepath) or "system")
+        start_num = int(match.group(2)) if match else 1
 
-            # Grafik-Position aktualisieren
-            parts = new_pos.split(",")
-            gx = float(parts[0].strip()) * self._scale
-            gz = float(parts[2].strip()) * self._scale
-            obj.setPos(gx - obj.rect().width() / 2,
-                       gz - obj.rect().height() / 2)
+        route_ids = str(chain[0].get("ids_name", "") or "").strip()
+        start_space_name = str(chain[0].get("tradelane_space_name", "") or "").strip()
+        end_space_name = str(chain[-1].get("tradelane_space_name", "") or "").strip()
+        loadout = _entry_value(first_obj, "loadout")
+        reputation = _entry_value(first_obj, "reputation")
+        difficulty_level = _entry_value(first_obj, "difficulty_level") or "1"
+        pilot = _entry_value(first_obj, "pilot") or "pilot_solar_easiest"
+        cfg = {
+            "ring_count": count,
+            "start_num": start_num,
+            "loadout": loadout,
+            "reputation": reputation,
+            "difficulty_level": int(str(difficulty_level or "1").strip() or "1"),
+            "pilot": pilot,
+            "ids_name": route_ids,
+            "space_name_start": start_space_name,
+            "space_name_end": end_space_name,
+        }
 
-            # Sektion in _sections aktualisieren
-            obj_idx = None
-            try:
-                obj_idx = self._objects.index(obj)
-            except ValueError:
-                continue
-            count_s = 0
-            for si, (sec_name, sec_entries) in enumerate(self._sections):
-                if sec_name.lower() == "object":
-                    if count_s == obj_idx:
-                        self._sections[si] = (sec_name, list(new_entries))
-                        break
-                    count_s += 1
-
+        self._remove_tradelane_chain_objects(chain)
+        self._generate_tradelane(
+            sx,
+            sz,
+            ex,
+            ez,
+            cfg,
+            system_nick,
+            refresh_3d=False,
+            select_created=False,
+            push_undo=False,
+            rebuild_combo=False,
+        )
+        self._rebuild_object_combo()
         self._pending_tl_reposition = None
         self._set_dirty(True)
         self._write_to_file(reload=False)

--- a/tests/test_main_window_smoke.py
+++ b/tests/test_main_window_smoke.py
@@ -5116,58 +5116,80 @@ def test_build_system_editor_host_uses_composite_system_view_resolvers(main_wind
     ) in calls
 
 
-def test_apply_tl_reposition_reapplies_object_y_rotation(main_window, monkeypatch):
-    class _Rect:
-        def width(self):
-            return 10.0
-
-        def height(self):
-            return 10.0
-
+def test_apply_tl_reposition_rebuilds_chain_with_recomputed_ring_count(main_window, monkeypatch):
     class _Obj:
-        def __init__(self):
-            self.nickname = "li01_trade_lane_ring_01"
+        def __init__(self, nickname: str, pos: str, space_name: str = ""):
+            self.nickname = nickname
             self.data = {
                 "rotate": "0, 0, 0",
+                "loadout": "trade_lane_ring_li01",
+                "pilot": "pilot_solar_easy",
+                "difficulty_level": "1",
+                "reputation": "li_n_grp",
+                "pos": pos,
+                "ids_name": "12345",
+                "tradelane_space_name": space_name,
                 "_entries": [
-                    ("nickname", "li01_trade_lane_ring_01"),
+                    ("nickname", nickname),
                     ("rotate", "0, 0, 0"),
-                    ("pos", "0, 0, 0"),
+                    ("pos", pos),
+                    ("ids_name", "12345"),
+                    ("loadout", "trade_lane_ring_li01"),
+                    ("pilot", "pilot_solar_easy"),
+                    ("difficulty_level", "1"),
+                    ("reputation", "li_n_grp"),
+                    *([("tradelane_space_name", space_name)] if space_name else []),
                 ],
             }
-            self.applied_rotation = None
-            self.pos_calls: list[tuple[float, float]] = []
 
-        def _apply_rotation_from_data(self):
-            self.applied_rotation = self.data.get("rotate")
+    obj_a = _Obj("li01_Trade_Lane_Ring_5", "0, 0, 0", "111")
+    obj_b = _Obj("li01_Trade_Lane_Ring_6", "7500, 0, 0")
+    obj_c = _Obj("li01_Trade_Lane_Ring_7", "15000, 0, 0", "222")
 
-        def setPos(self, x, y):
-            self.pos_calls.append((float(x), float(y)))
-
-        def rect(self):
-            return _Rect()
-
-    obj = _Obj()
+    main_window._filepath = "C:/mods/li01.ini"
     main_window._scale = 1.0
-    main_window._objects = [obj]
-    main_window._sections = [("Object", list(obj.data["_entries"]))]
     main_window._pending_tl_reposition = {
-        "chain": [{"_obj": obj}],
+        "chain": [
+            {"_obj": obj_a, "nickname": obj_a.nickname, "pos": obj_a.data["pos"], "ids_name": "12345", "tradelane_space_name": "111"},
+            {"_obj": obj_b, "nickname": obj_b.nickname, "pos": obj_b.data["pos"], "ids_name": "12345", "tradelane_space_name": ""},
+            {"_obj": obj_c, "nickname": obj_c.nickname, "pos": obj_c.data["pos"], "ids_name": "12345", "tradelane_space_name": "222"},
+        ],
         "new_start": QPointF(0.0, 0.0),
-        "new_end": QPointF(100.0, 0.0),
+        "new_end": QPointF(30000.0, 0.0),
     }
 
+    removed: list[list[dict]] = []
+    generated: list[tuple[float, float, float, float, dict, str]] = []
     write_calls: list[bool] = []
     refresh_calls: list[bool] = []
+    combo_calls: list[bool] = []
 
+    monkeypatch.setattr(main_window, "_remove_tradelane_chain_objects", lambda chain: removed.append(list(chain)))
+    monkeypatch.setattr(
+        main_window,
+        "_generate_tradelane",
+        lambda sx, sz, ex, ez, cfg, system_nick, **kwargs: generated.append((sx, sz, ex, ez, dict(cfg), system_nick)),
+    )
+    monkeypatch.setattr(main_window, "_rebuild_object_combo", lambda: combo_calls.append(True))
     monkeypatch.setattr(main_window, "_write_to_file", lambda reload=False: write_calls.append(bool(reload)))
     monkeypatch.setattr(main_window, "_refresh_3d_scene", lambda *args, **kwargs: refresh_calls.append(True))
 
     main_window._apply_tl_reposition()
 
-    assert obj.data["rotate"] == "0, -90, 0"
-    assert obj.applied_rotation == "0, -90, 0"
-    assert main_window._sections[0][1][1] == ("rotate", "0, -90, 0")
+    assert len(removed) == 1
+    assert len(generated) == 1
+    sx, sz, ex, ez, cfg, system_nick = generated[0]
+    assert (sx, sz, ex, ez) == (0.0, 0.0, 30000.0, 0.0)
+    assert cfg["ring_count"] == 5
+    assert cfg["start_num"] == 5
+    assert cfg["ids_name"] == "12345"
+    assert cfg["space_name_start"] == "111"
+    assert cfg["space_name_end"] == "222"
+    assert cfg["loadout"] == "trade_lane_ring_li01"
+    assert cfg["pilot"] == "pilot_solar_easy"
+    assert cfg["reputation"] == "li_n_grp"
+    assert system_nick == "li01"
+    assert combo_calls == [True]
     assert write_calls == [False]
     assert refresh_calls == [True]
 


### PR DESCRIPTION
## Summary
- rebuild tradelane routes with a recalculated ring count when start/end points are reset
- preserve route metadata while reusing the original spacing as the count baseline
- add a regression test for tradelane reposition count recalculation

Closes #54